### PR TITLE
feat: configure OIDC middleware via env

### DIFF
--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -2,4 +2,9 @@
  {:port    3031}
 
  :duct.database/sql
- {:connection-uri "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres"}}
+ {:connection-uri "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres"}
+ 
+ :etlp/middleware.auth
+ {:issuer   #duct/env ["OIDC_ISSUER"]
+  :audience #duct/env ["OIDC_AUDIENCE"]
+  :jwks-uri #duct/env ["OIDC_JWKS_URI"]}}

--- a/prod/resources/prod.edn
+++ b/prod/resources/prod.edn
@@ -5,4 +5,9 @@
  {:port 3000}
 
  :duct.database/sql
- {:connection-uri "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres"}}
+ {:connection-uri "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres"}
+
+ :etlp/middleware.auth
+ {:issuer   #duct/env ["OIDC_ISSUER"]
+  :audience #duct/env ["OIDC_AUDIENCE"]
+  :jwks-uri #duct/env ["OIDC_JWKS_URI"]}}

--- a/resources/prod.edn
+++ b/resources/prod.edn
@@ -5,4 +5,10 @@
  {:port 3000}
 
  :duct.database/sql
- {:connection-uri #duct/env ["JDBC_URL" :or "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres"]}}
+ {:connection-uri #duct/env ["JDBC_URL" :or "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres"]}
+
+ :etlp/middleware.auth
+ {:issuer   #duct/env ["OIDC_ISSUER"]
+  :audience #duct/env ["OIDC_AUDIENCE"]
+  :jwks-uri #duct/env ["OIDC_JWKS_URI"]}}
+


### PR DESCRIPTION
## Summary
- pass OIDC issuer, audience, and JWKS URI through `:etlp/middleware.auth` via environment variables
- mirror auth middleware config in production resources

## Testing
- `lein run` *(fails: lein not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7535c88f883208f88dc15361f4691