### PR TITLE
Fix middleware stack and add incremental org_id migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $  java -jar target/etlp-mapper-0.1.0-SNAPSHOT-standalone.jar
 
 ```
 
-The migrations create organization-aware `mappings` and `mappings_history` tables, each keyed by an `org_id` used to scope data per tenant.
+The migrations create organization-aware `mappings` and `mappings_history` tables, each keyed by an `org_id` used to scope data per tenant. Existing deployments can apply the new migrations to add these columns without dropping data.
 
 
 

--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -4,13 +4,13 @@
  :duct.database/sql
  {:connection-uri #duct/env ["JDBC_URL" :or "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres"]}
 
- :etlp/middleware.auth
+ :etlp-mapper.middleware/auth
  {:issuer   #duct/env ["OIDC_ISSUER"]
   :audience #duct/env ["OIDC_AUDIENCE"]
   :jwks-uri #duct/env ["OIDC_JWKS_URI"]}
 
- :etlp/middleware.require-org {}
+ :etlp-mapper.middleware/require-org {}
 
  :duct.middleware/stack
- {:middleware [#ig/ref :etlp/middleware.auth
-               #ig/ref :etlp/middleware.require-org]}}
+ {:middleware [#ig/ref :etlp-mapper.middleware/auth
+               #ig/ref :etlp-mapper.middleware/require-org]}}

--- a/resources/etlp_mapper/config.edn
+++ b/resources/etlp_mapper/config.edn
@@ -17,13 +17,13 @@
             [:post "/mappings/test"]
             [:etlp-mapper.handler/mappings]
 
-
             [:get    "/mappings/" id] [:etlp-mapper.handler.mappings/find ^int id]
             [:get    "/mappings/" id "/_history"] [:etlp-mapper.handler.mappings/history ^int id]
             [:get    "/mappings/" id "/_history/" version] [:etlp-mapper.handler.mappings/traverse-history ^int id version]
             [:delete "/mappings/" id] [:etlp-mapper.handler.mappings/destroy ^int id]}}
 
-  :duct.handler/root {:middleware [#ig/ref :etlp-mapper.handler/hello]}
+  :duct.handler/root {:middleware [#ig/ref :etlp/middleware.cors
+                                   #ig/ref :duct.middleware/stack]}
 
   :duct.migrator/ragtime
   {:migrations [#ig/ref :etlp-mapper.migration/create-mappings
@@ -31,14 +31,17 @@
                 #ig/ref :etlp-mapper.migration/insert-mapping-history
                 #ig/ref :etlp-mapper.migration/insert_mapping_history_trigger
                 #ig/ref :etlp-mapper.migration/updated-at-trigger
-                #ig/ref :etlp-mapper.migration/updated-mapping-trigger]}
+                #ig/ref :etlp-mapper.migration/updated-mapping-trigger
+                #ig/ref :etlp-mapper.migration/add-org-id-to-mappings
+                #ig/ref :etlp-mapper.migration/add-org-id-to-mappings-history
+                #ig/ref :etlp-mapper.migration/update-insert-mapping-history]}
 
   ; Mapper specific tables
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-mappings]
-  {:up ["CREATE TABLE mappings (id SERIAL PRIMARY KEY, org_id TEXT NOT NULL, title TEXT NOT NULL, content JSONB, created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP)"]
+  {:up ["CREATE TABLE mappings (id SERIAL PRIMARY KEY, title TEXT NOT NULL, content JSONB, created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP)"]
    :down ["DROP TABLE mappings"]}
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-mappings-history]
-  {:up ["CREATE TABLE mappings_history (id SERIAL PRIMARY KEY, original_id INT, org_id TEXT, txnid TEXT, title TEXT NOT NULL, content JSONB, created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP WITH TIME ZONE)"]
+  {:up ["CREATE TABLE mappings_history (id SERIAL PRIMARY KEY, original_id INT, txnid TEXT, title TEXT NOT NULL, content JSONB, created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP WITH TIME ZONE)"]
    :down ["DROP TABLE mappings_history"]}
 
 ;DB procedure and triggers for cross cutting concerns
@@ -49,24 +52,22 @@ DECLARE
   txnid TEXT;
 BEGIN
   txnid := txid_current();
-    INSERT INTO mappings_history (
-      title,
-      content,
-      created_at,
-      updated_at,
-      original_id,
-      org_id,
-      txnid
-    )
-    VALUES (
-      OLD.title,
-      OLD.content,
-      OLD.created_at,
-      OLD.updated_at,
-      OLD.id,
-      OLD.org_id,
-      txnid
-    );
+  INSERT INTO mappings_history (
+    title,
+    content,
+    created_at,
+    updated_at,
+    original_id,
+    txnid
+  )
+  VALUES (
+    OLD.title,
+    OLD.content,
+    OLD.created_at,
+    OLD.updated_at,
+    OLD.id,
+    txnid
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;"]
@@ -79,15 +80,79 @@ $$ LANGUAGE plpgsql;"]
    :down  ["DROP FUNCTION update_changetimestamp_column"]}
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/updated-mapping-trigger]
   {:up ["CREATE TRIGGER update_mapping_changetimestamp BEFORE UPDATE ON mappings FOR EACH ROW EXECUTE PROCEDURE update_changetimestamp_column();"]
-   :down  ["DROP TRIGGER update_mapping_changetimestamp"]}
+  :down  ["DROP TRIGGER update_mapping_changetimestamp"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/add-org-id-to-mappings]
+  {:up ["ALTER TABLE mappings ADD COLUMN org_id TEXT DEFAULT 'default';"
+        "ALTER TABLE mappings ALTER COLUMN org_id SET NOT NULL;"]
+   :down ["ALTER TABLE mappings DROP COLUMN org_id;"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/add-org-id-to-mappings-history]
+  {:up ["ALTER TABLE mappings_history ADD COLUMN org_id TEXT DEFAULT 'default';"
+        "ALTER TABLE mappings_history ALTER COLUMN org_id SET NOT NULL;"]
+   :down ["ALTER TABLE mappings_history DROP COLUMN org_id;"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/update-insert-mapping-history]
+  {:up ["CREATE OR REPLACE FUNCTION insert_mapping_history()"
+        "RETURNS TRIGGER AS $$"
+        "DECLARE"
+        "  txnid TEXT;"
+        "BEGIN"
+        "  txnid := txid_current();"
+        "  INSERT INTO mappings_history ("
+        "    title,"
+        "    content,"
+        "    created_at,"
+        "    updated_at,"
+        "    original_id,"
+        "    org_id,"
+        "    txnid"
+        "  )"
+        "  VALUES ("
+        "    OLD.title,"
+        "    OLD.content,"
+        "    OLD.created_at,"
+        "    OLD.updated_at,"
+        "    OLD.id,"
+        "    OLD.org_id,"
+        "    txnid"
+        "  );"
+        "  RETURN NEW;"
+        "END;"
+        "$$ LANGUAGE plpgsql;"]
+   :down ["CREATE OR REPLACE FUNCTION insert_mapping_history()"
+          "RETURNS TRIGGER AS $$"
+          "DECLARE"
+          "  txnid TEXT;"
+          "BEGIN"
+          "  txnid := txid_current();"
+          "  INSERT INTO mappings_history ("
+          "    title,"
+          "    content,"
+          "    created_at,"
+          "    updated_at,"
+          "    original_id,"
+          "    txnid"
+          "  )"
+          "  VALUES ("
+          "    OLD.title,"
+          "    OLD.content,"
+          "    OLD.created_at,"
+          "    OLD.updated_at,"
+          "    OLD.id,"
+          "    txnid"
+          "  );"
+          "  RETURN NEW;"
+          "END;"
+          "$$ LANGUAGE plpgsql;"]}
 
 ;Query handlers for Rest Endpoints
- [:duct.handler.sql/query :etlp-mapper.handler.mappings/list]
- {:request {{org-id :org/id} :identity}
-  :sql ["SELECT * FROM mappings WHERE org_id = ?" org-id]
-  :hrefs {:href "/mappings/{id}"}}
+  [:duct.handler.sql/query :etlp-mapper.handler.mappings/list]
+  {:request {{org-id :org/id} :identity}
+   :sql ["SELECT * FROM mappings WHERE org_id = ?" org-id]
+   :hrefs {:href "/mappings/{id}"}}
 
-  :etlp-mapper.handler/hello
+  :etlp/middleware.cors
   {}
 
   :etlp-mapper.handler/index
@@ -103,42 +168,42 @@ $$ LANGUAGE plpgsql;"]
   {:db #ig/ref :duct.database/sql
    :request {[_ id data] :ataraxy/result}}
 
- [:duct.handler.sql/insert :etlp-mapper.handler.mappings/create]
- {:request {[_ title content] :ataraxy/result
+  [:duct.handler.sql/insert :etlp-mapper.handler.mappings/create]
+  {:request {[_ title content] :ataraxy/result
             {org-id :org/id} :identity}
-  :sql     ["INSERT INTO mappings (title, content, org_id) VALUES (?, ?, ?)" title content org-id]
-  :location "mappings/{id}"
-  :hrefs {:href "/mappings/{id}"}}
+   :sql     ["INSERT INTO mappings (title, content, org_id) VALUES (?, ?, ?)" title content org-id]
+   :location "mappings/{id}"
+   :hrefs {:href "/mappings/{id}"}}
 
- [:duct.handler.sql/query-one :etlp-mapper.handler.mappings/find]
- {:request {[_ id] :ataraxy/result
+  [:duct.handler.sql/query-one :etlp-mapper.handler.mappings/find]
+  {:request {[_ id] :ataraxy/result
             {org-id :org/id} :identity}
-  :sql     ["SELECT * FROM mappings WHERE id = ? AND org_id = ?" id org-id]
-  :hrefs   {:href "/mappings/{id}"}}
+   :sql     ["SELECT * FROM mappings WHERE id = ? AND org_id = ?" id org-id]
+   :hrefs   {:href "/mappings/{id}"}}
 
- [:duct.handler.sql/execute :etlp-mapper.handler.mappings/destroy]
- {:request {[_ id] :ataraxy/result
+  [:duct.handler.sql/execute :etlp-mapper.handler.mappings/destroy]
+  {:request {[_ id] :ataraxy/result
             {org-id :org/id} :identity}
-  :sql     ["DELETE FROM mappings WHERE id = ? AND org_id = ?" id org-id]}
+   :sql     ["DELETE FROM mappings WHERE id = ? AND org_id = ?" id org-id]}
 
- [:duct.handler.sql/execute :etlp-mapper.handler.mappings/update]
- {:request {[_ id content] :ataraxy/result
+  [:duct.handler.sql/execute :etlp-mapper.handler.mappings/update]
+  {:request {[_ id content] :ataraxy/result
             {org-id :org/id} :identity}
-  :sql     ["UPDATE mappings SET content = ? WHERE id = ? AND org_id = ?" content id org-id]}
+   :sql     ["UPDATE mappings SET content = ? WHERE id = ? AND org_id = ?" content id org-id]}
 
- [:duct.handler.sql/query :etlp-mapper.handler.mappings/history]
- {:request {[_ id] :ataraxy/result
+  [:duct.handler.sql/query :etlp-mapper.handler.mappings/history]
+  {:request {[_ id] :ataraxy/result
             {org-id :org/id} :identity}
-  :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND m.org_id = ? AND mh.org_id = ?" id org-id org-id]
-  :hrefs {:href "/mappings/{id}/_history/{txnid}"}}
+   :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND m.org_id = ? AND mh.org_id = ?" id org-id org-id]
+   :hrefs {:href "/mappings/{id}/_history/{txnid}"}}
 
- [:duct.handler.sql/query-one :etlp-mapper.handler.mappings/traverse-history]
- {:request {[_ id version] :ataraxy/result
+  [:duct.handler.sql/query-one :etlp-mapper.handler.mappings/traverse-history]
+  {:request {[_ id version] :ataraxy/result
             {org-id :org/id} :identity}
-  :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND mh.txnid = ? AND m.org_id = ? AND mh.org_id = ?" id version org-id org-id]}}
+   :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND mh.txnid = ? AND m.org_id = ? AND mh.org_id = ?" id version org-id org-id]}}
 
  :duct.profile/dev   #duct/include "dev"
-; :duct.profile/local #duct/include "local"
+ ; :duct.profile/local #duct/include "local"
  :duct.profile/prod  #duct/include "prod.edn"
 
  :duct.module/logging {}

--- a/resources/etlp_mapper/config.edn
+++ b/resources/etlp_mapper/config.edn
@@ -22,7 +22,7 @@
             [:get    "/mappings/" id "/_history/" version] [:etlp-mapper.handler.mappings/traverse-history ^int id version]
             [:delete "/mappings/" id] [:etlp-mapper.handler.mappings/destroy ^int id]}}
 
-  :duct.handler/root {:middleware [#ig/ref :etlp/middleware.cors
+  :duct.handler/root {:middleware [#ig/ref :etlp-mapper.middleware/cors
                                    #ig/ref :duct.middleware/stack]}
 
   :duct.migrator/ragtime
@@ -152,7 +152,7 @@ $$ LANGUAGE plpgsql;"]
    :sql ["SELECT * FROM mappings WHERE org_id = ?" org-id]
    :hrefs {:href "/mappings/{id}"}}
 
-  :etlp/middleware.cors
+  :etlp-mapper.middleware/cors
   {}
 
   :etlp-mapper.handler/index

--- a/resources/prod.edn
+++ b/resources/prod.edn
@@ -7,13 +7,13 @@
  :duct.database/sql
  {:connection-uri #duct/env ["JDBC_URL" :or "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres"]}
 
- :etlp/middleware.auth
+ :etlp-mapper.middleware/auth
  {:issuer   #duct/env ["OIDC_ISSUER"]
   :audience #duct/env ["OIDC_AUDIENCE"]
   :jwks-uri #duct/env ["OIDC_JWKS_URI"]}
 
- :etlp/middleware.require-org {}
+ :etlp-mapper.middleware/require-org {}
 
  :duct.middleware/stack
- {:middleware [#ig/ref :etlp/middleware.auth
-               #ig/ref :etlp/middleware.require-org]}}
+ {:middleware [#ig/ref :etlp-mapper.middleware/auth
+               #ig/ref :etlp-mapper.middleware/require-org]}}

--- a/src/etlp_mapper/auth_component.clj
+++ b/src/etlp_mapper/auth_component.clj
@@ -3,15 +3,15 @@
   (:require [integrant.core :as ig]
             [etlp-mapper.auth :as auth]))
 
-(defmethod ig/init-key :etlp/middleware.auth
+(defmethod ig/init-key :etlp-mapper.middleware/auth
   [_ opts]
   (auth/wrap-auth opts))
 
-(defmethod ig/init-key :etlp/middleware.require-org
+(defmethod ig/init-key :etlp-mapper.middleware/require-org
   [_ _]
   (auth/wrap-require-org))
 
-(defmethod ig/init-key :etlp/middleware.require-role
+(defmethod ig/init-key :etlp-mapper.middleware/require-role
   [_ {:keys [role]}]
   (auth/require-role role))
 

--- a/src/etlp_mapper/handler/index.clj
+++ b/src/etlp_mapper/handler/index.clj
@@ -3,35 +3,6 @@
             [ataraxy.response :as response]
             [integrant.core :as ig]))
 
-(defmethod ig/init-key :etlp-mapper.handler/index [_ options]
+(defmethod ig/init-key :etlp-mapper.handler/index [_ _]
   (fn [{[_] :ataraxy/result}]
     [::response/ok {:message "I'm Clojure"}]))
-
-
-(defn hello-middleware
-  "Middleware that adds a custom header to responses."
-  [handler]
-  (fn [request]
-    (let [response (handler request)]
-      (assoc-in response [:headers "X-Hello"] "Hello, Duct!"))))
-
-
-(defn cors-middleware
-  "Middleware that allows CORS requests and handles preflight OPTIONS."
-  [handler]
-  (fn [request]
-    (if (= :options (:request-method request))
-      {:status  200
-       :headers {"Access-Control-Allow-Origin" "*"
-                 "Access-Control-Allow-Methods" "GET, POST, PUT, DELETE, OPTIONS"
-                 "Access-Control-Allow-Headers" "Content-Type, Authorization"}
-       :body    "OK"}
-      (let [response (handler request)]
-        (-> response
-            (assoc-in [:headers "Access-Control-Allow-Origin"] "*")
-            (assoc-in [:headers "Access-Control-Allow-Methods"] "GET, POST, PUT, DELETE, OPTIONS")
-            (assoc-in [:headers "Access-Control-Allow-Headers"] "Content-Type, Authorization"))))))
-
-
-(defmethod ig/init-key :etlp-mapper.handler/hello [_ _]
-  cors-middleware)

--- a/src/etlp_mapper/middlewares.clj
+++ b/src/etlp_mapper/middlewares.clj
@@ -11,6 +11,6 @@
              :access-control-allow-methods [:get :post :put :delete :options]
              :access-control-allow-headers ["Content-Type" "Authorization"]))
 
-(defmethod ig/init-key :etlp/middleware.cors
+(defmethod ig/init-key :etlp-mapper.middleware/cors
   [_ _]
   cors-middleware)

--- a/src/etlp_mapper/middlewares.clj
+++ b/src/etlp_mapper/middlewares.clj
@@ -2,3 +2,15 @@
   (:require
     [ring.middleware.cors :refer [wrap-cors]]
     [integrant.core :as ig]))
+
+(defn cors-middleware
+  "Allow cross-origin requests for common HTTP methods and headers."
+  [handler]
+  (wrap-cors handler
+             :access-control-allow-origin [#".*"]
+             :access-control-allow-methods [:get :post :put :delete :options]
+             :access-control-allow-headers ["Content-Type" "Authorization"]))
+
+(defmethod ig/init-key :etlp/middleware.cors
+  [_ _]
+  cors-middleware)


### PR DESCRIPTION
## Summary
- introduce dedicated CORS middleware and wire it into the global stack
- add incremental migrations to append org_id support without dropping data
- document that migrations can be applied safely on existing deployments

## Testing
- `lein test`

------
https://chatgpt.com/codex/tasks/task_e_68b87c7449188320b705921f6381be2e