### PR TITLE
Ensure org context before executing handler

### DIFF
--- a/src/etlp_mapper/auth.clj
+++ b/src/etlp_mapper/auth.clj
@@ -70,7 +70,6 @@
       (fn [req]
         (if-let [token (bearer-token req)]
           (try
-            (print req)
             (let [decoded (verify token)
                   claims  (decode-claims decoded)
                   org-id  (:org_id claims)
@@ -89,11 +88,9 @@
   ([]
    (fn [handler]
      (fn [req]
-       (let [resp (handler req)]
-         (cond
-           (get-in resp [:identity :org/id]) resp
-           (= 200 (:status resp)) (forbidden "Organization context required")
-           :else resp))))))
+       (if (get-in req [:identity :org/id])
+         (handler req)
+         (forbidden "Organization context required"))))))
 
 (defn require-role
   "Middleware factory enforcing that the authenticated identity has the


### PR DESCRIPTION
## Summary
- Check for `:org/id` in request identity before invoking downstream handler
- Update tests to verify forbidden responses and skip handler when organization context is missing
- Remove leftover debug printing from authentication middleware

## Testing
- `/tmp/lein test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0789f12c832094203c3120187455