### PR TITLE
Add organization migrations and update mapping references

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $  java -jar target/etlp-mapper-0.1.0-SNAPSHOT-standalone.jar
 
 ```
 
-The migrations create organization-aware `mappings` and `mappings_history` tables, each keyed by an `org_id` used to scope data per tenant. Existing deployments can apply the new migrations to add these columns without dropping data.
+The migrations create organization-aware `mappings` and `mappings_history` tables, each keyed by an `organization_id` used to scope data per tenant.
 
 
 

--- a/resources/etlp_mapper/config.edn
+++ b/resources/etlp_mapper/config.edn
@@ -28,23 +28,56 @@
 
 
   :duct.migrator/ragtime
-  {:migrations [#ig/ref :etlp-mapper.migration/create-mappings
+  {:migrations [#ig/ref :etlp-mapper.migration/create-organizations
+                #ig/ref :etlp-mapper.migration/create-users
+                #ig/ref :etlp-mapper.migration/create-organization-members
+                #ig/ref :etlp-mapper.migration/create-organization-invites
+                #ig/ref :etlp-mapper.migration/create-organization-subscriptions
+                #ig/ref :etlp-mapper.migration/create-audit-logs
+                #ig/ref :etlp-mapper.migration/create-ai-usage-logs
+                #ig/ref :etlp-mapper.migration/create-mappings
                 #ig/ref :etlp-mapper.migration/create-mappings-history
                 #ig/ref :etlp-mapper.migration/insert-mapping-history
                 #ig/ref :etlp-mapper.migration/insert_mapping_history_trigger
                 #ig/ref :etlp-mapper.migration/updated-at-trigger
-                #ig/ref :etlp-mapper.migration/updated-mapping-trigger
-                #ig/ref :etlp-mapper.migration/add-org-id-to-mappings
-                #ig/ref :etlp-mapper.migration/add-org-id-to-mappings-history
-                #ig/ref :etlp-mapper.migration/update-insert-mapping-history]}
+                #ig/ref :etlp-mapper.migration/updated-mapping-trigger]}
+
+  ; Core tables
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-organizations]
+  {:up ["CREATE TABLE organizations (id UUID PRIMARY KEY, name TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP); CREATE UNIQUE INDEX organizations_name_idx ON organizations(name);"]
+   :down ["DROP TABLE organizations;"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-users]
+  {:up ["CREATE TABLE users (id UUID PRIMARY KEY, email TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP); CREATE UNIQUE INDEX users_email_idx ON users(email);"]
+   :down ["DROP TABLE users;"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-organization-members]
+  {:up ["CREATE TABLE organization_members (organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE, user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE, role TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (organization_id, user_id)); CREATE INDEX organization_members_user_id_idx ON organization_members(user_id);"]
+   :down ["DROP TABLE organization_members;"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-organization-invites]
+  {:up ["CREATE TABLE organization_invites (id UUID PRIMARY KEY, organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE, email TEXT NOT NULL, token TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP); CREATE INDEX organization_invites_organization_id_idx ON organization_invites(organization_id); CREATE UNIQUE INDEX organization_invites_token_idx ON organization_invites(token);"]
+   :down ["DROP TABLE organization_invites;"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-organization-subscriptions]
+  {:up ["CREATE TABLE organization_subscriptions (organization_id UUID PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE, plan TEXT NOT NULL, status TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP); CREATE INDEX organization_subscriptions_status_idx ON organization_subscriptions(status);"]
+   :down ["DROP TABLE organization_subscriptions;"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-audit-logs]
+  {:up ["CREATE TABLE audit_logs (id BIGSERIAL PRIMARY KEY, organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE, user_id UUID REFERENCES users(id), action TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP); CREATE INDEX audit_logs_organization_id_idx ON audit_logs(organization_id); CREATE INDEX audit_logs_user_id_idx ON audit_logs(user_id);"]
+   :down ["DROP TABLE audit_logs;"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-ai-usage-logs]
+  {:up ["CREATE TABLE ai_usage_logs (id BIGSERIAL PRIMARY KEY, organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE, user_id UUID REFERENCES users(id), model TEXT NOT NULL, input_tokens INT NOT NULL, output_tokens INT NOT NULL, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP); CREATE INDEX ai_usage_logs_organization_id_idx ON ai_usage_logs(organization_id); CREATE INDEX ai_usage_logs_user_id_idx ON ai_usage_logs(user_id);"]
+   :down ["DROP TABLE ai_usage_logs;"]}
 
   ; Mapper specific tables
-  [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-mappings]
-  {:up ["CREATE TABLE mappings (id SERIAL PRIMARY KEY, title TEXT NOT NULL, content JSONB, created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP)"]
-   :down ["DROP TABLE mappings"]}
-  [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-mappings-history]
-  {:up ["CREATE TABLE mappings_history (id SERIAL PRIMARY KEY, original_id INT, txnid TEXT, title TEXT NOT NULL, content JSONB, created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP WITH TIME ZONE)"]
-   :down ["DROP TABLE mappings_history"]}
+    [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-mappings]
+    {:up ["CREATE TABLE mappings (id SERIAL PRIMARY KEY, title TEXT NOT NULL, content JSONB, organization_id UUID NOT NULL REFERENCES organizations(id), created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP); CREATE INDEX mappings_organization_id_idx ON mappings(organization_id);"]
+     :down ["DROP TABLE mappings;"]}
+    [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-mappings-history]
+    {:up ["CREATE TABLE mappings_history (id SERIAL PRIMARY KEY, original_id INT, txnid TEXT, title TEXT NOT NULL, content JSONB, organization_id UUID NOT NULL REFERENCES organizations(id), created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP); CREATE INDEX mappings_history_original_id_idx ON mappings_history(original_id); CREATE INDEX mappings_history_organization_id_idx ON mappings_history(organization_id);"]
+     :down ["DROP TABLE mappings_history;"]}
 
 ;DB procedure and triggers for cross cutting concerns
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/insert-mapping-history]
@@ -60,6 +93,7 @@ BEGIN
     created_at,
     updated_at,
     original_id,
+    organization_id,
     txnid
   )
   VALUES (
@@ -68,92 +102,29 @@ BEGIN
     OLD.created_at,
     OLD.updated_at,
     OLD.id,
+    OLD.organization_id,
     txnid
   );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;"]
-   :down ["DROP FUNCTION insert_mapping_history"]}
+   :down ["DROP FUNCTION insert_mapping_history;"]}
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/insert_mapping_history_trigger]
   {:up ["CREATE TRIGGER insert_mapping_history_trigger BEFORE UPDATE ON mappings FOR EACH ROW EXECUTE FUNCTION insert_mapping_history();"]
-   :down ["DROP TRIGGER insert_mapping_history_trigger"]}
+   :down ["DROP TRIGGER insert_mapping_history_trigger ON mappings;"]}
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/updated-at-trigger]
   {:up ["CREATE OR REPLACE FUNCTION update_changetimestamp_column() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = now(); RETURN NEW; END; $$ language 'plpgsql';"]
-   :down  ["DROP FUNCTION update_changetimestamp_column"]}
+   :down  ["DROP FUNCTION update_changetimestamp_column;"]}
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/updated-mapping-trigger]
   {:up ["CREATE TRIGGER update_mapping_changetimestamp BEFORE UPDATE ON mappings FOR EACH ROW EXECUTE PROCEDURE update_changetimestamp_column();"]
-   :down  ["DROP TRIGGER update_mapping_changetimestamp"]}
+   :down  ["DROP TRIGGER update_mapping_changetimestamp ON mappings;"]}
 
-  [:duct.migrator.ragtime/sql :etlp-mapper.migration/add-org-id-to-mappings]
-  {:up ["ALTER TABLE mappings ADD COLUMN org_id TEXT DEFAULT 'default';"
-        "ALTER TABLE mappings ALTER COLUMN org_id SET NOT NULL;"]
-   :down ["ALTER TABLE mappings DROP COLUMN org_id;"]}
-
-  [:duct.migrator.ragtime/sql :etlp-mapper.migration/add-org-id-to-mappings-history]
-  {:up ["ALTER TABLE mappings_history ADD COLUMN org_id TEXT DEFAULT 'default';"
-        "ALTER TABLE mappings_history ALTER COLUMN org_id SET NOT NULL;"]
-   :down ["ALTER TABLE mappings_history DROP COLUMN org_id;"]}
-
-  [:duct.migrator.ragtime/sql :etlp-mapper.migration/update-insert-mapping-history]
-  {:up   ["CREATE OR REPLACE FUNCTION insert_mapping_history()
-           RETURNS TRIGGER AS $$
-           DECLARE
-             txnid TEXT;
-           BEGIN
-             txnid := txid_current();
-             INSERT INTO mappings_history (
-               title,
-               content,
-               created_at,
-               updated_at,
-               original_id,
-               org_id,
-               txnid
-             )
-             VALUES (
-               OLD.title,
-               OLD.content,
-               OLD.created_at,
-               OLD.updated_at,
-               OLD.id,
-               OLD.org_id,
-               txnid
-             );
-             RETURN NEW;
-           END;
-           $$ LANGUAGE plpgsql;"]
-
-   :down ["CREATE OR REPLACE FUNCTION insert_mapping_history()
-           RETURNS TRIGGER AS $$
-           DECLARE
-             txnid TEXT;
-           BEGIN
-             txnid := txid_current();
-             INSERT INTO mappings_history (
-               title,
-               content,
-               created_at,
-               updated_at,
-               original_id,
-               txnid
-             )
-             VALUES (
-               OLD.title,
-               OLD.content,
-               OLD.created_at,
-               OLD.updated_at,
-               OLD.id,
-               txnid
-             );
-             RETURN NEW;
-           END;
-           $$ LANGUAGE plpgsql;"]}
 
 
 ;Query handlers for Rest Endpoints
   [:duct.handler.sql/query :etlp-mapper.handler.mappings/list]
   {:request {{org-id :org/id} :identity}
-   :sql ["SELECT * FROM mappings WHERE org_id = ?" org-id]
+   :sql ["SELECT * FROM mappings WHERE organization_id = ?" org-id]
    :hrefs {:href "/mappings/{id}"}}
 
   :etlp-mapper.middlewares/cors
@@ -176,37 +147,37 @@ $$ LANGUAGE plpgsql;"]
   {:request {[_ title content] :ataraxy/result
              {org-id :org/id} :identity}
 
-   :sql     ["INSERT INTO mappings (title, content, org_id) VALUES (?, ?, ?)" title content org-id]
+   :sql     ["INSERT INTO mappings (title, content, organization_id) VALUES (?, ?, ?)" title content org-id]
    :location "mappings/{id}"
    :hrefs {:href "/mappings/{id}"}}
 
   [:duct.handler.sql/query-one :etlp-mapper.handler.mappings/find]
   {:request {[_ id] :ataraxy/result
              {org-id :org/id} :identity}
-   :sql     ["SELECT * FROM mappings WHERE id = ? AND org_id = ?" id org-id]
+   :sql     ["SELECT * FROM mappings WHERE id = ? AND organization_id = ?" id org-id]
    :hrefs   {:href "/mappings/{id}"}}
 
   [:duct.handler.sql/execute :etlp-mapper.handler.mappings/destroy]
   {:request {[_ id] :ataraxy/result
              {org-id :org/id} :identity}
 
-   :sql     ["DELETE FROM mappings WHERE id = ? AND org_id = ?" id org-id]}
+   :sql     ["DELETE FROM mappings WHERE id = ? AND organization_id = ?" id org-id]}
 
   [:duct.handler.sql/execute :etlp-mapper.handler.mappings/update]
   {:request {[_ id content] :ataraxy/result
              {org-id :org/id} :identity}
-   :sql     ["UPDATE mappings SET content = ? WHERE id = ? AND org_id = ?" content id org-id]}
+   :sql     ["UPDATE mappings SET content = ? WHERE id = ? AND organization_id = ?" content id org-id]}
 
   [:duct.handler.sql/query :etlp-mapper.handler.mappings/history]
   {:request {[_ id] :ataraxy/result
              {org-id :org/id} :identity}
-   :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND m.org_id = ? AND mh.org_id = ?" id org-id org-id]
+   :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND m.organization_id = ? AND mh.organization_id = ?" id org-id org-id]
    :hrefs {:href "/mappings/{id}/_history/{txnid}"}}
 
   [:duct.handler.sql/query-one :etlp-mapper.handler.mappings/traverse-history]
   {:request {[_ id version] :ataraxy/result
              {org-id :org/id} :identity}
-   :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND mh.txnid = ? AND m.org_id = ? AND mh.org_id = ?" id version org-id org-id]}}
+   :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND mh.txnid = ? AND m.organization_id = ? AND mh.organization_id = ?" id version org-id org-id]}}
 
  :duct.profile/dev   #duct/include "dev"
  ; :duct.profile/local #duct/include "local"

--- a/src/etlp_mapper/handler/mappings.clj
+++ b/src/etlp_mapper/handler/mappings.clj
@@ -22,7 +22,7 @@
 (extend-protocol Mappings
   duct.database.sql.Boundary
   (apply-mapping [{db :spec} org-id id data]
-    (let [results (jdbc/query db ["select * from mappings where id = ? and org_id = ?" id org-id])
+      (let [results (jdbc/query db ["select * from mappings where id = ? and organization_id = ?" id org-id])
           template (-> results
                        first
                        :content


### PR DESCRIPTION
## Summary
- add migrations for organizations, users and related tables
- switch mappings and history to organization_id referencing organizations
- update SQL queries and handler to use organization_id

## Testing
- `lein test`

------
https://chatgpt.com/codex/tasks/task_e_68c0b1d54f6883208286e9c32adecb1b