### PR TITLE
Add database namespaces for organization and user management

### DIFF
--- a/src/etlp_mapper/ai_usage_logs.clj
+++ b/src/etlp_mapper/ai_usage_logs.clj
@@ -1,0 +1,22 @@
+(ns etlp-mapper.ai-usage-logs
+  "Database helpers for AI usage logging."
+  (:require [clojure.java.jdbc :as jdbc]
+            duct.database.sql))
+
+(defprotocol AIUsageLogs
+  (find-usage [db id]
+    "Find a usage record by id.")
+  (find-usage-for-org [db org-id]
+    "List usage records for an organization.")
+  (log-usage [db data]
+    "Insert a new usage record."))
+
+(extend-protocol AIUsageLogs
+  duct.database.sql.Boundary
+  (find-usage [{db :spec} id]
+    (first (jdbc/query db ["select * from ai_usage_logs where id = ?" id])))
+  (find-usage-for-org [{db :spec} org-id]
+    (jdbc/query db ["select * from ai_usage_logs where org_id = ?" org-id]))
+  (log-usage [{db :spec} data]
+    (first (jdbc/insert! db :ai_usage_logs data))))
+

--- a/src/etlp_mapper/audit_logs.clj
+++ b/src/etlp_mapper/audit_logs.clj
@@ -1,0 +1,22 @@
+(ns etlp-mapper.audit-logs
+  "Database helpers for storing audit log entries."
+  (:require [clojure.java.jdbc :as jdbc]
+            duct.database.sql))
+
+(defprotocol AuditLogs
+  (find-log [db id]
+    "Find a log entry by id.")
+  (find-logs [db org-id]
+    "List log entries for an organization.")
+  (create-log [db data]
+    "Insert a new audit log entry."))
+
+(extend-protocol AuditLogs
+  duct.database.sql.Boundary
+  (find-log [{db :spec} id]
+    (first (jdbc/query db ["select * from audit_logs where id = ?" id])))
+  (find-logs [{db :spec} org-id]
+    (jdbc/query db ["select * from audit_logs where org_id = ? order by created_at desc" org-id]))
+  (create-log [{db :spec} data]
+    (first (jdbc/insert! db :audit_logs data))))
+

--- a/src/etlp_mapper/organization_invites.clj
+++ b/src/etlp_mapper/organization_invites.clj
@@ -1,0 +1,54 @@
+(ns etlp-mapper.organization-invites
+  "Database access and token helpers for organization invites."
+  (:require [clojure.java.jdbc :as jdbc]
+            duct.database.sql)
+  (:import (com.auth0.jwt JWT)
+           (com.auth0.jwt.algorithms Algorithm)))
+
+(defprotocol OrganizationInvites
+  (find-invite [db token]
+    "Find an invite by token.")
+  (create-invite [db data]
+    "Create a new invite record.")
+  (upsert-invite [db data]
+    "Insert or update an invite by token.")
+  (consume-invite [db token]
+    "Delete an invite by token."))
+
+(defn sign-token
+  "Sign invite claims with a shared secret and return a JWT string."
+  [secret claims]
+  (let [algo (Algorithm/HMAC256 secret)
+        builder (reduce (fn [b [k v]] (.withClaim b (name k) (str v)))
+                        (JWT/create)
+                        claims)]
+    (.sign builder algo)))
+
+(defn verify-token
+  "Verify an invite token using the shared secret.
+   Returns the claims map or nil if verification fails."
+  [secret token]
+  (let [algo (Algorithm/HMAC256 secret)
+        verifier (-> (JWT/require algo) .build)]
+    (try
+      (let [decoded (.verify verifier token)
+            claims (.getClaims decoded)]
+        (into {}
+              (for [[k v] claims]
+                [(keyword k) (.asString v)])))
+      (catch Exception _ nil))))
+
+(extend-protocol OrganizationInvites
+  duct.database.sql.Boundary
+  (find-invite [{db :spec} token]
+    (first (jdbc/query db ["select * from organization_invites where token = ?" token])))
+  (create-invite [{db :spec} data]
+    (first (jdbc/insert! db :organization_invites data)))
+  (upsert-invite [db data]
+    (if (find-invite db (:token data))
+      (jdbc/update! (:spec db) :organization_invites (dissoc data :token)
+                    ["token = ?" (:token data)])
+      (create-invite db data)))
+  (consume-invite [{db :spec} token]
+    (jdbc/delete! db :organization_invites ["token = ?" token])))
+

--- a/src/etlp_mapper/organization_members.clj
+++ b/src/etlp_mapper/organization_members.clj
@@ -1,0 +1,34 @@
+(ns etlp-mapper.organization-members
+  "Database access for organization membership and helper checks."
+  (:require [clojure.java.jdbc :as jdbc]
+            duct.database.sql))
+
+(defprotocol OrganizationMembers
+  (find-members [db org-id]
+    "Return all members for an organization.")
+  (add-member [db data]
+    "Add a membership record.")
+  (remove-member [db org-id user-id]
+    "Remove a user from an organization.")
+  (member? [db org-id user-id]
+    "Check if a user belongs to an organization.")
+  (has-role? [db org-id user-id role]
+    "Check if a user has a role in an organization."))
+
+(extend-protocol OrganizationMembers
+  duct.database.sql.Boundary
+  (find-members [{db :spec} org-id]
+    (jdbc/query db ["select * from organization_members where org_id = ?" org-id]))
+  (add-member [{db :spec} data]
+    (first (jdbc/insert! db :organization_members data)))
+  (remove-member [{db :spec} org-id user-id]
+    (jdbc/delete! db :organization_members ["org_id = ? and user_id = ?" org-id user-id]))
+  (member? [{db :spec} org-id user-id]
+    (-> (jdbc/query db ["select 1 from organization_members where org_id = ? and user_id = ? limit 1" org-id user-id])
+        empty?
+        not))
+  (has-role? [{db :spec} org-id user-id role]
+    (-> (jdbc/query db ["select 1 from organization_members where org_id = ? and user_id = ? and role = ? limit 1" org-id user-id role])
+        empty?
+        not)))
+

--- a/src/etlp_mapper/organization_subscriptions.clj
+++ b/src/etlp_mapper/organization_subscriptions.clj
@@ -1,0 +1,28 @@
+(ns etlp-mapper.organization-subscriptions
+  "Database access for organization subscriptions."
+  (:require [clojure.java.jdbc :as jdbc]
+            duct.database.sql))
+
+(defprotocol OrganizationSubscriptions
+  (find-subscription [db org-id]
+    "Find a subscription for the organization.")
+  (create-subscription [db data]
+    "Create a new subscription record.")
+  (update-subscription [db org-id data]
+    "Update a subscription by organization id.")
+  (upsert-subscription [db data]
+    "Insert or update a subscription by :org_id in data."))
+
+(extend-protocol OrganizationSubscriptions
+  duct.database.sql.Boundary
+  (find-subscription [{db :spec} org-id]
+    (first (jdbc/query db ["select * from organization_subscriptions where org_id = ?" org-id])))
+  (create-subscription [{db :spec} data]
+    (first (jdbc/insert! db :organization_subscriptions data)))
+  (update-subscription [{db :spec} org-id data]
+    (jdbc/update! db :organization_subscriptions data ["org_id = ?" org-id]))
+  (upsert-subscription [db data]
+    (if (find-subscription db (:org_id data))
+      (update-subscription db (:org_id data) (dissoc data :org_id))
+      (create-subscription db data))))
+

--- a/src/etlp_mapper/organizations.clj
+++ b/src/etlp_mapper/organizations.clj
@@ -1,0 +1,32 @@
+(ns etlp-mapper.organizations
+  "Database access functions for organizations."
+  (:require [clojure.java.jdbc :as jdbc]
+            duct.database.sql))
+
+(defprotocol Organizations
+  (find-org [db id]
+    "Find an organization by id.")
+  (create-org [db data]
+    "Create a new organization and return the inserted row.")
+  (update-org [db id data]
+    "Update organization by id with data map.")
+  (delete-org [db id]
+    "Delete organization by id.")
+  (upsert-org [db data]
+    "Insert or update organization by :id in data."))
+
+(extend-protocol Organizations
+  duct.database.sql.Boundary
+  (find-org [{db :spec} id]
+    (first (jdbc/query db ["select * from organizations where id = ?" id])))
+  (create-org [{db :spec} data]
+    (first (jdbc/insert! db :organizations data)))
+  (update-org [{db :spec} id data]
+    (jdbc/update! db :organizations data ["id = ?" id]))
+  (delete-org [{db :spec} id]
+    (jdbc/delete! db :organizations ["id = ?" id]))
+  (upsert-org [db data]
+    (if (find-org db (:id data))
+      (update-org db (:id data) (dissoc data :id))
+      (create-org db data))))
+

--- a/src/etlp_mapper/users.clj
+++ b/src/etlp_mapper/users.clj
@@ -1,0 +1,36 @@
+(ns etlp-mapper.users
+  "Database access functions for users."
+  (:require [clojure.java.jdbc :as jdbc]
+            duct.database.sql))
+
+(defprotocol Users
+  (find-user [db id]
+    "Find user by id.")
+  (find-user-by-email [db email]
+    "Find user by email address.")
+  (create-user [db data]
+    "Create a new user.")
+  (update-user [db id data]
+    "Update a user with given id and data map.")
+  (delete-user [db id]
+    "Delete user by id.")
+  (upsert-user [db data]
+    "Insert or update a user by :id in data."))
+
+(extend-protocol Users
+  duct.database.sql.Boundary
+  (find-user [{db :spec} id]
+    (first (jdbc/query db ["select * from users where id = ?" id])))
+  (find-user-by-email [{db :spec} email]
+    (first (jdbc/query db ["select * from users where email = ?" email])))
+  (create-user [{db :spec} data]
+    (first (jdbc/insert! db :users data)))
+  (update-user [{db :spec} id data]
+    (jdbc/update! db :users data ["id = ?" id]))
+  (delete-user [{db :spec} id]
+    (jdbc/delete! db :users ["id = ?" id]))
+  (upsert-user [db data]
+    (if (find-user db (:id data))
+      (update-user db (:id data) (dissoc data :id))
+      (create-user db data))))
+


### PR DESCRIPTION
## Summary
- add organizations, users, organization members, invites, and subscription namespaces with CRUD helpers
- introduce audit and AI usage logging namespaces
- provide JWT signing/verification for organization invites

## Testing
- `lein test`
- `lein clj-kondo-lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0b23faff48320b6940db2b4479d00