### PR TITLE
Add stub handlers for org and invite management

### DIFF
--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -9,6 +9,4 @@
   :audience #duct/env ["OIDC_AUDIENCE" :or "mapify-api"]
   :jwks-uri #duct/env ["OIDC_JWKS_URI" :or "http://localhost:8080/realms/mapify/protocol/openid-connect/certs"]}
 
- :etlp-mapper.auth-component/require-org {}
-
- :etlp-mapper.auth-component/require-role {}}
+ :etlp-mapper.auth-component/require-org {}}

--- a/resources/etlp_mapper/config.edn
+++ b/resources/etlp_mapper/config.edn
@@ -4,6 +4,11 @@
   :duct.router/ataraxy
   {:routes {[:get "/"] [:etlp-mapper.handler/index]
             [:get "/whoami"] [:etlp-mapper.handler/whoami]
+            [:post "/orgs"] [:etlp-mapper.handler.orgs/create]
+            [:post "/orgs/" org-id "/invites"] [:etlp-mapper.handler.invites/create org-id]
+            [:post "/invites/accept"] [:etlp-mapper.handler.invites/accept]
+            [:post "/me/active-org"] [:etlp-mapper.handler.me/set-active-org]
+            [:post "/billing/portal"] [:etlp-mapper.handler.billing/portal]
             [:get "/mappings"] [:etlp-mapper.handler.mappings/list]
             [:post "/mappings" {{:keys [title content]} :body-params}]
             [:etlp-mapper.handler.mappings/create title content]
@@ -165,12 +170,22 @@ $$ LANGUAGE plpgsql;"]
   :etlp-mapper.handler/whoami
   {}
 
-  :etlp-mapper.handler/mappings
+  :etlp-mapper.handler.mappings
   {:db #ig/ref :duct.database/sql}
 
   :etlp-mapper.handler/apply-mappings
   {:db #ig/ref :duct.database/sql
    :request {[_ id data] :ataraxy/result}}
+
+  :etlp-mapper.handler.orgs/create {}
+
+  :etlp-mapper.handler.invites/create {}
+
+  :etlp-mapper.handler.invites/accept {}
+
+  :etlp-mapper.handler.me/set-active-org {}
+
+  :etlp-mapper.handler.billing/portal {}
 
   [:duct.handler.sql/insert :etlp-mapper.handler.mappings/create]
   {:request {[_ title content] :ataraxy/result
@@ -207,6 +222,9 @@ $$ LANGUAGE plpgsql;"]
   {:request {[_ id version] :ataraxy/result
              {org-id :org/id} :identity}
    :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND mh.txnid = ? AND m.org_id = ? AND mh.org_id = ?" id version org-id org-id]}}
+
+  :etlp-mapper.auth-component/require-org {}
+  :etlp-mapper.auth-component/require-role {:role :editor}
 
  :duct.profile/dev   #duct/include "dev"
  ; :duct.profile/local #duct/include "local"

--- a/src/etlp_mapper/handler/billing.clj
+++ b/src/etlp_mapper/handler/billing.clj
@@ -1,0 +1,17 @@
+(ns etlp-mapper.handler.billing
+  (:require [ataraxy.response :as response]
+            [integrant.core :as ig]))
+
+(defn- admin-role? [roles]
+  (some #{:owner "owner" :admin "admin"} roles))
+
+;; POST /billing/portal – return a stubbed billing portal URL for owners or
+;; administrators of the active organisation.
+(defmethod ig/init-key :etlp-mapper.handler.billing/portal
+  [_ _]
+  (fn [request]
+    (let [roles (get-in request [:identity :claims :roles])]
+      (if (admin-role? roles)
+        [::response/ok {:url "https://billing.example.com/portal"}]
+        [::response/forbidden {:error "Insufficient role"}]))))
+

--- a/src/etlp_mapper/handler/invites.clj
+++ b/src/etlp_mapper/handler/invites.clj
@@ -1,0 +1,30 @@
+(ns etlp-mapper.handler.invites
+  (:require [ataraxy.response :as response]
+            [integrant.core :as ig]))
+
+(defn- admin-role? [roles]
+  (some #{:owner "owner" :admin "admin"} roles))
+
+;; POST /orgs/:org-id/invites – create an invite token.  Requires the caller to
+;; have an admin or owner role within the organisation.  Token generation and
+;; persistence are stubbed out.
+(defmethod ig/init-key :etlp-mapper.handler.invites/create
+  [_ _]
+  (fn [{[_ org-id] :ataraxy/result :as request}]
+    (let [roles (get-in request [:identity :claims :roles])]
+      (if (admin-role? roles)
+        (let [token (str (java.util.UUID/randomUUID))]
+          [::response/ok {:org_id org-id :token token}])
+        [::response/forbidden {:error "Insufficient role"}]))))
+
+;; POST /invites/accept – accept an invite token.  In a full system the token
+;; would be validated and the user added to the organisation along with an
+;; audit entry.  Here we simply echo back the token and supplied organisation
+;; identifier.
+(defmethod ig/init-key :etlp-mapper.handler.invites/accept
+  [_ _]
+  (fn [{{:keys [token org_id]} :body-params}]
+    (if token
+      [::response/ok {:org_id org_id :token token :status "accepted"}]
+      [::response/bad-request {:error "Invalid token"}])))
+

--- a/src/etlp_mapper/handler/me.clj
+++ b/src/etlp_mapper/handler/me.clj
@@ -1,0 +1,12 @@
+(ns etlp-mapper.handler.me
+  (:require [ataraxy.response :as response]
+            [integrant.core :as ig]))
+
+;; POST /me/active-org – set the currently active organisation for the user.
+;; The real implementation would persist this choice and perhaps issue a new
+;; token.  Here we simply echo back the requested organisation identifier.
+(defmethod ig/init-key :etlp-mapper.handler.me/set-active-org
+  [_ _]
+  (fn [{{:keys [org_id]} :body-params}]
+    [::response/ok {:org_id org_id}]))
+

--- a/src/etlp_mapper/handler/orgs.clj
+++ b/src/etlp_mapper/handler/orgs.clj
@@ -1,0 +1,17 @@
+(ns etlp-mapper.handler.orgs
+  (:require [ataraxy.response :as response]
+            [integrant.core :as ig]))
+
+;; Handler for creating a new organization. Requires an authenticated user
+;; without an active organisation association. The real implementation would
+;; create the org, membership, subscription and audit log entries. Here we
+;; simply generate a UUID for the new organisation and return it.
+
+(defmethod ig/init-key :etlp-mapper.handler.orgs/create
+  [_ _]
+  (fn [request]
+    (if (get-in request [:identity :org/id])
+      [::response/forbidden {:error "Organization already selected"}]
+      (let [new-id (str (java.util.UUID/randomUUID))]
+        [::response/ok {:org_id new-id}]))))
+

--- a/src/etlp_mapper/handler/whoami.clj
+++ b/src/etlp_mapper/handler/whoami.clj
@@ -6,10 +6,11 @@
   [_ _]
   (fn [request]
     (let [claims (get-in request [:identity :claims])
-          org-id (get-in request [:identity :org/id])]
-      [::response/ok {:org_id org-id
-                      :sub (:sub claims)
-                      :email (:email claims)
-                      :exp (:exp claims)
+          org-id (get-in request [:identity :org/id])
+          user   {:sub   (:sub claims)
+                  :email (:email claims)
+                  :exp   (:exp claims)}]
+      [::response/ok {:user   user
+                      :org_id org-id
                       :roles (:roles claims)}])))
 


### PR DESCRIPTION
## Summary
- Simplify whoami to report user, org and roles
- Introduce stub handlers for org creation, invites, active-org and billing portal
- Extend router configuration for new endpoints and basic middleware

## Testing
- `lein test` *(fails: Don't know how to create ISeq from: etlp_mapper.auth$require_role$fn__3345$fn__3346)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b24b12988320af5ddc1d9b67390c