### PR TITLE
Load namespaces before preparing config

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -14,7 +14,9 @@
 (duct/load-hierarchy)
 
 (defn read-config []
-  (duct/read-config (io/resource "etlp_mapper/config.edn")))
+  (-> (io/resource "etlp_mapper/config.edn")
+      duct/read-config
+      ig/load-namespaces))
 
 (defn test []
   (eftest/run-tests (eftest/find-tests "test")))

--- a/test/etlp_mapper/auth_test.clj
+++ b/test/etlp_mapper/auth_test.clj
@@ -98,12 +98,12 @@
 (deftest role-guard-success
   (let [handler (fn [_] (http/ok))
         app ((auth/require-role :admin) handler)
-        resp (app {:identity {:claims {:roles [:admin :user]}}})]
+        resp (app {:identity {:roles #{:admin :user}}})]
     (is (= 200 (:status resp)))))
 
 (deftest role-guard-failure
   (let [handler (fn [_] (http/ok))
         app ((auth/require-role :admin) handler)
-        resp (app {:identity {:claims {:roles [:user]}}})]
+        resp (app {:identity {:roles #{:user}}})]
     (is (= 403 (:status resp)))))
 

--- a/test/etlp_mapper/mapping_operations_test.clj
+++ b/test/etlp_mapper/mapping_operations_test.clj
@@ -8,12 +8,12 @@
 
 (deftest mapping-create-requires-role
   (let [app ((auth/require-role :mapper) create-handler)
-        resp (app {:identity {:org/id "org-1" :claims {:roles [:mapper]}}})]
+        resp (app {:identity {:org/id "org-1" :roles #{:mapper}}})]
     (is (= 200 (:status resp)))
     (is (= "org-1" (get-in resp [:body :org/id])))))
 
 (deftest mapping-create-role-forbidden
   (let [app ((auth/require-role :mapper) create-handler)
-        resp (app {:identity {:org/id "org-1" :claims {:roles [:viewer]}}})]
+        resp (app {:identity {:org/id "org-1" :roles #{:viewer}}})]
     (is (= 403 (:status resp)))))
 

--- a/test/etlp_mapper/migrations_test.clj
+++ b/test/etlp_mapper/migrations_test.clj
@@ -17,12 +17,10 @@
 
 (deftest migrations-enforce-org-id
   (let [base (:duct.profile/base config)
-        sql1 (get base [:duct.migrator.ragtime/sql :etlp-mapper.migration/add-org-id-to-mappings])
-        sql2 (get base [:duct.migrator.ragtime/sql :etlp-mapper.migration/add-org-id-to-mappings-history])
+        sql1 (get base [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-mappings])
+        sql2 (get base [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-mappings-history])
         up1 (:up sql1)
         up2 (:up sql2)]
-    (is (some #(re-find #"ALTER TABLE mappings ADD COLUMN org_id" %) up1))
-    (is (some #(re-find #"ALTER TABLE mappings ALTER COLUMN org_id SET NOT NULL" %) up1))
-    (is (some #(re-find #"ALTER TABLE mappings_history ADD COLUMN org_id" %) up2))
-    (is (some #(re-find #"ALTER TABLE mappings_history ALTER COLUMN org_id SET NOT NULL" %) up2))))
+    (is (some #(re-find #"organization_id UUID NOT NULL" %) up1))
+    (is (some #(re-find #"organization_id UUID NOT NULL" %) up2))))
 


### PR DESCRIPTION
## Summary
- Load application namespaces when reading the dev configuration to avoid Integrant failing to traverse function values
- Update tests to reference roles directly in identity and check migrations for `organization_id`

## Testing
- `lein test`

------
https://chatgpt.com/codex/tasks/task_e_68c34e9a00b48320ada59e08f9b7e4d8