### PR TITLE
Fix upsert-user SQL binding

### DIFF
--- a/src/etlp_mapper/auth.clj
+++ b/src/etlp_mapper/auth.clj
@@ -67,9 +67,9 @@
   [{db :spec} {:keys [idp-sub email name]}]
   (first
    (jdbc/query db
-               ["insert into users as u (idp_sub,email,name) values (?,?,?) "
-                "on conflict (idp_sub) do update set email=excluded.email, name=excluded.name "
-                "returning u.id, u.email, u.idp_sub, u.last_used_org_id"
+               [(str "insert into users as u (idp_sub,email,name) values (?,?,?) "
+                     "on conflict (idp_sub) do update set email=excluded.email, name=excluded.name "
+                     "returning u.id, u.email, u.idp_sub, u.last_used_org_id")
                 idp-sub email name])))
 
 


### PR DESCRIPTION
## Summary
- fix `upsert-user!` to compose SQL in a single string and bind three params
- add a unit test ensuring the SQL string and parameter binding

## Testing
- `lein test`
- `lein clj-kondo-lint` *(fails: warnings: 35)*

------
https://chatgpt.com/codex/tasks/task_e_68c375b7130883208207d1681a0fd453