### PR TITLE
Check organization exists before updating last org

### DIFF
--- a/src/etlp_mapper/auth.clj
+++ b/src/etlp_mapper/auth.clj
@@ -74,8 +74,14 @@
 
 
 (defn- update-last-org!
+  "Update the user's `last_used_org_id` only if the organization exists.
+
+  This prevents violating the `users_last_used_org_id_fkey` when a user
+  provides an organization identifier that isn't present in the
+  `organizations` table."
   [{db :spec} user-id org-id]
-  (jdbc/execute! db ["update users set last_used_org_id=? where id=?" org-id user-id]))
+  (when (seq (jdbc/query db ["select 1 from organizations where id=?" org-id]))
+    (jdbc/execute! db ["update users set last_used_org_id=? where id=?" org-id user-id])))
 
 
 (defn- load-user-roles


### PR DESCRIPTION
## Summary
- verify organization exists before updating a user's `last_used_org_id`

## Testing
- `lein test`
- `lein clj-kondo --lint src/etlp_mapper/auth.clj`


------
https://chatgpt.com/codex/tasks/task_e_68c380a3e3488320b85d0920f1a3cb5f