### PR TITLE
Attach raw claims to request identity

### DIFF
--- a/src/etlp_mapper/auth.clj
+++ b/src/etlp_mapper/auth.clj
@@ -119,7 +119,8 @@
                                    :email (:email user)
                                    :idp-sub (:idp_sub user)}
                             :org/id org-id
-                            :roles roles}
+                            :roles roles
+                            :claims claims}
                   resp    (handler (assoc req :identity identity))]
               (assoc resp :identity identity))
             (catch JWTVerificationException _

--- a/src/etlp_mapper/handler/invites.clj
+++ b/src/etlp_mapper/handler/invites.clj
@@ -12,10 +12,10 @@
 (defmethod ig/init-key :etlp-mapper.handler.invites/create
   [_ {:keys [db]}]
   (fn [{[_ org-id] :ataraxy/result :as request}]
-    (let [roles (get-in request [:identity :claims :roles])]
+    (let [roles (get-in request [:identity :roles])]
       (if (admin-role? roles)
         (let [token (str (java.util.UUID/randomUUID))
-              user-id (get-in request [:identity :claims :sub])]
+              user-id (get-in request [:identity :user :id])]
           (audit-logs/log! db {:org-id org-id
                                :user-id user-id
                                :action "create-invite"
@@ -30,7 +30,7 @@
 (defmethod ig/init-key :etlp-mapper.handler.invites/accept
   [_ {:keys [db]}]
   (fn [{{:keys [token org_id]} :body-params :as request}]
-    (let [user-id (get-in request [:identity :claims :sub])]
+    (let [user-id (get-in request [:identity :user :id])]
       (if token
         (do
           (audit-logs/log! db {:org-id org_id

--- a/src/etlp_mapper/handler/orgs.clj
+++ b/src/etlp_mapper/handler/orgs.clj
@@ -14,7 +14,7 @@
     (if (get-in request [:identity :org/id])
       [::response/forbidden {:error "Organization already selected"}]
       (let [new-id (str (java.util.UUID/randomUUID))
-            user-id (get-in request [:identity :claims :sub])]
+            user-id (get-in request [:identity :user :id])]
         (audit-logs/log! db {:org-id new-id
                              :user-id user-id
                              :action "create-organization"})

--- a/src/etlp_mapper/handler/whoami.clj
+++ b/src/etlp_mapper/handler/whoami.clj
@@ -5,12 +5,12 @@
 (defmethod ig/init-key :etlp-mapper.handler/whoami
   [_ _]
   (fn [request]
-    (let [claims (get-in request [:identity :claims])
-          org-id (get-in request [:identity :org/id])
-          user   {:sub   (:sub claims)
-                  :email (:email claims)
-                  :exp   (:exp claims)}]
+    (let [identity (:identity request)
+          user (-> (:user identity)
+                   (assoc :exp (get-in identity [:claims :exp])))
+          org-id (:org/id identity)
+          roles (:roles identity)]
       [::response/ok {:user   user
                       :org_id org-id
-                      :roles (:roles claims)}])))
+                      :roles roles}])))
 

--- a/test/etlp_mapper/auth_test.clj
+++ b/test/etlp_mapper/auth_test.clj
@@ -46,7 +46,8 @@
                                  "x-org-id" "org-1"}})]
         (is (= 200 (:status resp)))
         (is (= "org-1" (get-in resp [:body :org/id])))
-        (is (= #{:admin} (get-in resp [:body :roles])))))))
+        (is (= #{:admin} (get-in resp [:body :roles])))
+        (is (= "sub-1" (get-in resp [:body :claims :sub])))))))
 
 (deftest jwt-missing-org
   (let [{:keys [token verifier]} (gen-token {:sub "s" :email "e" :name "n"})

--- a/test/etlp_mapper/handler/whoami_test.clj
+++ b/test/etlp_mapper/handler/whoami_test.clj
@@ -1,0 +1,17 @@
+(ns etlp-mapper.handler.whoami-test
+  (:require [clojure.test :refer :all]
+            [integrant.core :as ig]
+            [ataraxy.response :as response]
+            [etlp-mapper.handler.whoami]))
+
+(deftest whoami-reads-identity
+  (let [handler (ig/init-key :etlp-mapper.handler/whoami {})
+        resp    (handler {:identity {:user {:id 1 :email "e" :idp-sub "s"}
+                                     :roles #{:admin}
+                                     :org/id "org-1"
+                                     :claims {:exp 123}}})]
+    (is (= ::response/ok (first resp)))
+    (is (= {:id 1 :email "e" :idp-sub "s" :exp 123}
+           (:user (second resp))))
+    (is (= "org-1" (:org_id (second resp))))
+    (is (= #{:admin} (:roles (second resp))))))


### PR DESCRIPTION
## Summary
- expose decoded JWT claims under `:claims` in auth identity map
- refactor org, invite, and whoami handlers to use `:identity :user` and `:identity :roles`
- add tests for auth claims and whoami identity

## Testing
- `lein test`

------
https://chatgpt.com/codex/tasks/task_e_68c3873b0e1083209d0cfc45ba510932