### PR TITLE
Scope require-role per route

### DIFF
--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -10,9 +10,7 @@
   :jwks-uri #duct/env ["OIDC_JWKS_URI" :or "http://localhost:8080/realms/mapify/protocol/openid-connect/certs"]
   :db       #ig/ref :duct.database/sql}
 
- :etlp-mapper.auth-component/require-org {}
-
- :etlp-mapper.auth-component/require-role {}
+   :etlp-mapper.auth-component/require-org {}
 
  :etlp-mapper.invite/token
  {:app-secret #duct/env ["APP_SECRET" :or "dev-secret"]

--- a/resources/etlp_mapper/config.edn
+++ b/resources/etlp_mapper/config.edn
@@ -28,7 +28,6 @@
             [:delete "/mappings/" id] [:etlp-mapper.handler.mappings/destroy ^int id]}}
 
   :duct.handler/root {:middleware [#ig/ref :etlp-mapper.auth-component/require-org
-                                   #ig/ref :etlp-mapper.auth-component/require-role
                                    #ig/ref :etlp-mapper.auth-component/auth
                                    #ig/ref :etlp-mapper.middlewares/cors]}
 
@@ -131,7 +130,8 @@ $$ LANGUAGE plpgsql;"]
   [:duct.handler.sql/query :etlp-mapper.handler.mappings/list]
   {:request {{org-id :org/id} :identity}
    :sql ["SELECT * FROM mappings WHERE organization_id = ?::uuid" org-id]
-   :hrefs {:href "/mappings/{id}"}}
+   :hrefs {:href "/mappings/{id}"}
+   :middleware [#ig/ref :etlp-mapper.auth-component/require-role-mapper]}
 
   :etlp-mapper.middlewares/cors
   {}
@@ -143,57 +143,69 @@ $$ LANGUAGE plpgsql;"]
   {}
 
   :etlp-mapper.handler.mappings
-  {:db #ig/ref :duct.database/sql}
+  {:db #ig/ref :duct.database/sql
+   :middleware [#ig/ref :etlp-mapper.auth-component/require-role-mapper]}
 
   :etlp-mapper.handler/apply-mappings
   {:db #ig/ref :duct.database/sql
-   :request {[_ id data] :ataraxy/result}}
+   :request {[_ id data] :ataraxy/result}
+   :middleware [#ig/ref :etlp-mapper.auth-component/require-role-mapper]}
 
   :etlp-mapper.handler.orgs/create {:db #ig/ref :duct.database/sql}
 
-  :etlp-mapper.handler.invites/create {:db #ig/ref :duct.database/sql}
+  :etlp-mapper.handler.invites/create {:db #ig/ref :duct.database/sql
+                                       :middleware [#ig/ref :etlp-mapper.auth-component/require-role-admin]}
 
   :etlp-mapper.handler.invites/accept {:db #ig/ref :duct.database/sql}
 
   :etlp-mapper.handler.me/set-active-org {}
 
-  :etlp-mapper.handler.billing/portal {}
+  :etlp-mapper.handler.billing/portal {:middleware [#ig/ref :etlp-mapper.auth-component/require-role-admin]}
+
+  :etlp-mapper.auth-component/require-role-admin {:role :admin}
+  :etlp-mapper.auth-component/require-role-mapper {:role :mapper}
 
   [:duct.handler.sql/insert :etlp-mapper.handler.mappings/create]
   {:request {[_ title content] :ataraxy/result
              {org-id :org/id} :identity}
 
-   :sql     ["INSERT INTO mappings (title, content, organization_id) VALUES (?, ?, CAST(? AS UUID))" title content org-id]
-   :location "mappings/{id}"
-   :hrefs {:href "/mappings/{id}"}}
+  :sql     ["INSERT INTO mappings (title, content, organization_id) VALUES (?, ?, CAST(? AS UUID))" title content org-id]
+  :location "mappings/{id}"
+   :hrefs {:href "/mappings/{id}"}
+   :middleware [#ig/ref :etlp-mapper.auth-component/require-role-mapper]}
 
   [:duct.handler.sql/query-one :etlp-mapper.handler.mappings/find]
   {:request {[_ id] :ataraxy/result
              {org-id :org/id} :identity}
    :sql     ["SELECT * FROM mappings WHERE id = ? AND organization_id = ?::uuid" id org-id]
-   :hrefs   {:href "/mappings/{id}"}}
+   :hrefs   {:href "/mappings/{id}"}
+   :middleware [#ig/ref :etlp-mapper.auth-component/require-role-mapper]}
 
   [:duct.handler.sql/execute :etlp-mapper.handler.mappings/destroy]
   {:request {[_ id] :ataraxy/result
              {org-id :org/id} :identity}
 
-   :sql     ["DELETE FROM mappings WHERE id = ? AND organization_id = ?::uuid" id org-id]}
+   :sql     ["DELETE FROM mappings WHERE id = ? AND organization_id = ?::uuid" id org-id]
+   :middleware [#ig/ref :etlp-mapper.auth-component/require-role-mapper]}
 
   [:duct.handler.sql/execute :etlp-mapper.handler.mappings/update]
   {:request {[_ id content] :ataraxy/result
              {org-id :org/id} :identity}
-   :sql     ["UPDATE mappings SET content = ? WHERE id = ? AND organization_id = ?::uuid" content id org-id]}
+   :sql     ["UPDATE mappings SET content = ? WHERE id = ? AND organization_id = ?::uuid" content id org-id]
+   :middleware [#ig/ref :etlp-mapper.auth-component/require-role-mapper]}
 
   [:duct.handler.sql/query :etlp-mapper.handler.mappings/history]
   {:request {[_ id] :ataraxy/result
              {org-id :org/id} :identity}
    :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND m.organization_id = ? AND mh.organization_id = ?::uuid" id org-id org-id]
-   :hrefs {:href "/mappings/{id}/_history/{txnid}"}}
+   :hrefs {:href "/mappings/{id}/_history/{txnid}"}
+   :middleware [#ig/ref :etlp-mapper.auth-component/require-role-mapper]}
 
   [:duct.handler.sql/query-one :etlp-mapper.handler.mappings/traverse-history]
   {:request {[_ id version] :ataraxy/result
              {org-id :org/id} :identity}
-   :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND mh.txnid = ? AND m.organization_id = ? AND mh.organization_id = ?::uuid" id version org-id org-id]}}
+   :sql ["SELECT mh.title, mh.content, mh.created_at, mh.updated_at, mh.txnid FROM mappings m JOIN mappings_history mh ON m.id = mh.original_id WHERE m.id = ? AND mh.txnid = ? AND m.organization_id = ? AND mh.organization_id = ?::uuid" id version org-id org-id]
+   :middleware [#ig/ref :etlp-mapper.auth-component/require-role-mapper]}}
 
 
  ;:etlp-mapper/etlp {}


### PR DESCRIPTION
## Summary
- remove require-role middleware from the global stack so authentication runs first
- gate admin endpoints with `:require-role-admin`
- gate mapping endpoints with `:require-role-mapper`

## Testing
- `lein test`

------
https://chatgpt.com/codex/tasks/task_e_68c3873da7e8832086513d6607488dd9