### PR TITLE
Add organization invites columns and handlers

### DIFF
--- a/resources/etlp_mapper/config.edn
+++ b/resources/etlp_mapper/config.edn
@@ -62,7 +62,7 @@
    :down ["DROP TABLE organization_members;"]}
 
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-organization-invites]
-  {:up ["CREATE TABLE organization_invites (id UUID PRIMARY KEY, organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE, email TEXT NOT NULL, token TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP); CREATE INDEX organization_invites_organization_id_idx ON organization_invites(organization_id); CREATE UNIQUE INDEX organization_invites_token_idx ON organization_invites(token);"]
+  {:up ["CREATE TABLE organization_invites (id UUID PRIMARY KEY, organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE, email TEXT NOT NULL, role TEXT NOT NULL, token TEXT NOT NULL, status TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP, expires_at TIMESTAMPTZ); CREATE INDEX organization_invites_organization_id_idx ON organization_invites(organization_id); CREATE UNIQUE INDEX organization_invites_token_idx ON organization_invites(token);"]
    :down ["DROP TABLE organization_invites;"]}
 
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-organization-subscriptions]

--- a/src/etlp_mapper/handler/invites.clj
+++ b/src/etlp_mapper/handler/invites.clj
@@ -1,7 +1,8 @@
 (ns etlp-mapper.handler.invites
   (:require [ataraxy.response :as response]
             [integrant.core :as ig]
-            [etlp-mapper.audit-logs :as audit-logs]))
+            [etlp-mapper.audit-logs :as audit-logs]
+            [etlp-mapper.organization-invites :as org-invites]))
 
 (defn- admin-role? [roles]
   (some #{:owner "owner" :admin "admin"} roles))
@@ -11,16 +12,23 @@
 ;; persistence are stubbed out.
 (defmethod ig/init-key :etlp-mapper.handler.invites/create
   [_ {:keys [db]}]
-  (fn [{[_ org-id] :ataraxy/result :as request}]
+  (fn [{[_ org-id] :ataraxy/result {:keys [email role]} :body-params :as request}]
     (let [roles (get-in request [:identity :claims :roles])]
       (if (admin-role? roles)
         (let [token (str (java.util.UUID/randomUUID))
-              user-id (get-in request [:identity :claims :sub])]
+              user-id (get-in request [:identity :claims :sub])
+              invite {:id (java.util.UUID/randomUUID)
+                      :organization_id org-id
+                      :email email
+                      :role role
+                      :token token
+                      :status "pending"}]
+          (org-invites/create-invite db invite)
           (audit-logs/log! db {:org-id org-id
                                :user-id user-id
                                :action "create-invite"
                                :context {:token token}})
-          [::response/ok {:org_id org-id :token token}])
+          [::response/ok {:org_id org-id :token token :status "pending"}])
         [::response/forbidden {:error "Insufficient role"}]))))
 
 ;; POST /invites/accept – accept an invite token.  In a full system the token
@@ -29,13 +37,14 @@
 ;; identifier.
 (defmethod ig/init-key :etlp-mapper.handler.invites/accept
   [_ {:keys [db]}]
-  (fn [{{:keys [token org_id]} :body-params :as request}]
+  (fn [{{:keys [token]} :body-params :as request}]
     (let [user-id (get-in request [:identity :claims :sub])]
-      (if token
+      (if-let [invite (org-invites/find-invite db token)]
         (do
-          (audit-logs/log! db {:org-id org_id
+          (org-invites/consume-invite db token)
+          (audit-logs/log! db {:org-id (:organization_id invite)
                                :user-id user-id
                                :action "accept-invite"
                                :context {:token token}})
-          [::response/ok {:org_id org_id :token token :status "accepted"}])
+          [::response/ok {:org_id (:organization_id invite) :token token :status "accepted"}])
         [::response/bad-request {:error "Invalid token"}]))))

--- a/src/etlp_mapper/organization_invites.clj
+++ b/src/etlp_mapper/organization_invites.clj
@@ -50,5 +50,6 @@
                     ["token = ?" (:token data)])
       (create-invite db data)))
   (consume-invite [{db :spec} token]
-    (jdbc/delete! db :organization_invites ["token = ?" token])))
+    (jdbc/update! db :organization_invites {:status "accepted"}
+                  ["token = ?" token])))
 

--- a/test/etlp_mapper/migrations_test.clj
+++ b/test/etlp_mapper/migrations_test.clj
@@ -31,3 +31,11 @@
     (is (some #(re-find #"idp_sub TEXT NOT NULL" %) up))
     (is (some #(re-find #"last_used_org_id UUID" %) up))))
 
+(deftest migrations-organization-invites-table
+  (let [base (:duct.profile/base config)
+        sql  (get base [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-organization-invites])
+        up   (:up sql)]
+    (is (some #(re-find #"role TEXT NOT NULL" %) up))
+    (is (some #(re-find #"status TEXT NOT NULL" %) up))
+    (is (some #(re-find #"expires_at TIMESTAMPTZ" %) up))))
+

--- a/test/etlp_mapper/onboarding_test.clj
+++ b/test/etlp_mapper/onboarding_test.clj
@@ -12,8 +12,9 @@
     (swap! db assoc-in [:orgs id] {:id id :name name})
     id))
 
-(defn send-invite [org-id email]
-  (swap! db assoc-in [:invites email] {:org-id org-id :status :pending}))
+(defn send-invite [org-id email role]
+  (swap! db assoc-in [:invites email]
+             {:org-id org-id :role role :token "token" :status :pending}))
 
 (defn accept-invite [email]
   (swap! db update-in [:invites email] assoc :status :accepted))
@@ -23,7 +24,7 @@
 
 (deftest onboarding-flow
   (let [org-id (create-org "Acme")
-        _ (send-invite org-id "user@example.com")
+        _ (send-invite org-id "user@example.com" :member)
         _ (accept-invite "user@example.com")
         _ (set-active-org "user@example.com" org-id)]
     (is (= org-id (get-in @db [:active "user@example.com"])))


### PR DESCRIPTION
## Summary
- expand `organization_invites` migration with role, status and expiration fields
- track invite consumption via status and persist invites in create/accept handlers
- cover new columns in migration tests and update onboarding helpers

## Testing
- `lein test`


------
https://chatgpt.com/codex/tasks/task_e_68c3873f71908320919db60c733cc7b9