### PR TITLE
Handle signed invites and membership acceptance

### DIFF
--- a/resources/etlp_mapper/config.edn
+++ b/resources/etlp_mapper/config.edn
@@ -151,9 +151,11 @@ $$ LANGUAGE plpgsql;"]
 
   :etlp-mapper.handler.orgs/create {:db #ig/ref :duct.database/sql}
 
-  :etlp-mapper.handler.invites/create {:db #ig/ref :duct.database/sql}
+  :etlp-mapper.handler.invites/create {:db #ig/ref :duct.database/sql
+                                       :token #ig/ref :etlp-mapper.invite/token}
 
-  :etlp-mapper.handler.invites/accept {:db #ig/ref :duct.database/sql}
+  :etlp-mapper.handler.invites/accept {:db #ig/ref :duct.database/sql
+                                       :token #ig/ref :etlp-mapper.invite/token}
 
   :etlp-mapper.handler.me/set-active-org {}
 

--- a/src/etlp_mapper/handler/invites.clj
+++ b/src/etlp_mapper/handler/invites.clj
@@ -1,41 +1,58 @@
 (ns etlp-mapper.handler.invites
   (:require [ataraxy.response :as response]
             [integrant.core :as ig]
-            [etlp-mapper.audit-logs :as audit-logs]))
-
-(defn- admin-role? [roles]
-  (some #{:owner "owner" :admin "admin"} roles))
+            [etlp-mapper.audit-logs :as audit-logs]
+            [etlp-mapper.auth :as auth]
+            [etlp-mapper.organization-invites :as org-invites]
+            [etlp-mapper.organization-members :as org-members]))
 
 ;; POST /orgs/:org-id/invites – create an invite token.  Requires the caller to
-;; have an admin or owner role within the organisation.  Token generation and
-;; persistence are stubbed out.
+;; have an admin role within the organisation.
 (defmethod ig/init-key :etlp-mapper.handler.invites/create
-  [_ {:keys [db]}]
-  (fn [{[_ org-id] :ataraxy/result :as request}]
-    (let [roles (get-in request [:identity :claims :roles])]
-      (if (admin-role? roles)
-        (let [token (str (java.util.UUID/randomUUID))
-              user-id (get-in request [:identity :claims :sub])]
-          (audit-logs/log! db {:org-id org-id
-                               :user-id user-id
-                               :action "create-invite"
-                               :context {:token token}})
-          [::response/ok {:org_id org-id :token token}])
-        [::response/forbidden {:error "Insufficient role"}]))))
+  [_ {:keys [db token]}]
+  (let [{:keys [app-secret]} token
+        handler (fn [{[_ org-id] :ataraxy/result
+                      {:keys [email]} :body-params
+                      :as request}]
+                  (if email
+                    (let [token-str (org-invites/sign-token app-secret
+                                                           {:org-id org-id
+                                                            :email email})
+                          invite-id (str (java.util.UUID/randomUUID))
+                          user-id (get-in request [:identity :user :id])]
+                      (org-invites/upsert-invite db {:id invite-id
+                                                     :organization_id org-id
+                                                     :email email
+                                                     :token token-str})
+                      (audit-logs/log! db {:org-id org-id
+                                           :user-id user-id
+                                           :action "create-invite"
+                                           :context {:token token-str
+                                                     :email email}})
+                      [::response/ok {:org_id org-id :token token-str}])
+                    [::response/bad-request {:error "Email required"}]))]
+    ((auth/require-role :admin) handler)))
 
-;; POST /invites/accept – accept an invite token.  In a full system the token
-;; would be validated and the user added to the organisation along with an
-;; audit entry.  Here we simply echo back the token and supplied organisation
-;; identifier.
+;; POST /invites/accept – verify an invite token and add the user to the
+;; organisation membership list.
 (defmethod ig/init-key :etlp-mapper.handler.invites/accept
-  [_ {:keys [db]}]
-  (fn [{{:keys [token org_id]} :body-params :as request}]
-    (let [user-id (get-in request [:identity :claims :sub])]
-      (if token
-        (do
-          (audit-logs/log! db {:org-id org_id
-                               :user-id user-id
-                               :action "accept-invite"
-                               :context {:token token}})
-          [::response/ok {:org_id org_id :token token :status "accepted"}])
-        [::response/bad-request {:error "Invalid token"}]))))
+  [_ {:keys [db token]}]
+  (let [{:keys [app-secret]} token]
+    (fn [{{token :token} :body-params :as request}]
+      (let [user-id (get-in request [:identity :user :id])
+            claims  (when token (org-invites/verify-token app-secret token))
+            invite  (when token (org-invites/find-invite db token))]
+        (if (and claims invite)
+          (do
+            (org-members/add-member db {:organization_id (:organization_id invite)
+                                        :user_id user-id
+                                        :role "mapper"})
+            (org-invites/consume-invite db token)
+            (audit-logs/log! db {:org-id (:organization_id invite)
+                                 :user-id user-id
+                                 :action "accept-invite"
+                                 :context {:token token}})
+            [::response/ok {:org_id (:organization_id invite)
+                            :token token
+                            :status "accepted"}])
+          [::response/bad-request {:error "Invalid token"}])))))

--- a/test/etlp_mapper/invites_handler_test.clj
+++ b/test/etlp_mapper/invites_handler_test.clj
@@ -1,0 +1,57 @@
+(ns etlp-mapper.invites-handler-test
+  (:require [clojure.test :refer :all]
+            [integrant.core :as ig]
+            [etlp-mapper.handler.invites]
+            [etlp-mapper.organization-invites :as org-invites]
+            [etlp-mapper.organization-members :as org-members]
+            [etlp-mapper.audit-logs :as audit-logs]))
+
+(deftest create-requires-admin
+  (let [app (ig/init-key :etlp-mapper.handler.invites/create {:db ::db
+                                                              :token {:app-secret "s"}})
+        resp (app {:ataraxy/result [nil "org-1"]
+                    :body-params {:email "user@example.com"}
+                    :identity {:user {:id "u1"}
+                               :roles #{:user}}})]
+    (is (= 403 (:status resp)))))
+
+(deftest create-stores-invite
+  (let [secret "s"
+        captured (atom nil)
+        log-captured (atom nil)
+        app (ig/init-key :etlp-mapper.handler.invites/create {:db ::db
+                                                               :token {:app-secret secret}})]
+    (with-redefs [org-invites/upsert-invite (fn [_ data] (reset! captured data))
+                  audit-logs/log! (fn [_ data] (reset! log-captured data))]
+      (let [resp (app {:ataraxy/result [nil "org-1"]
+                       :body-params {:email "user@example.com"}
+                       :identity {:user {:id "user-1"}
+                                  :roles #{:admin}}})]
+        (is (= 200 (:status resp)))
+        (is (:token (:body resp)))
+        (is (= "org-1" (:organization_id @captured)))
+        (is (= "user@example.com" (:email @captured)))
+        (is (= "create-invite" (:action @log-captured)))
+        (is (org-invites/verify-token secret (:token (:body resp)))))))
+
+(deftest accept-invite-adds-member
+  (let [secret "s"
+        token  (org-invites/sign-token secret {:org-id "org-1" :email "u@example.com"})
+        add-captured (atom nil)
+        consume? (atom false)
+        log-captured (atom nil)
+        app (ig/init-key :etlp-mapper.handler.invites/accept {:db ::db
+                                                              :token {:app-secret secret}})]
+    (with-redefs [org-invites/find-invite (fn [_ t]
+                                            (when (= t token)
+                                              {:organization_id "org-1" :email "u@example.com"}))
+                  org-invites/consume-invite (fn [_ _] (reset! consume? true))
+                  org-members/add-member (fn [_ data] (reset! add-captured data))
+                  audit-logs/log! (fn [_ data] (reset! log-captured data))]
+      (let [resp (app {:body-params {:token token}
+                       :identity {:user {:id "user-1"}}})]
+        (is (= 200 (:status resp)))
+        (is (= {:organization_id "org-1" :user_id "user-1" :role "mapper"}
+               @add-captured))
+        (is @consume?)
+        (is (= "accept-invite" (:action @log-captured)))))))


### PR DESCRIPTION
## Summary
- Sign invite tokens with `APP_SECRET`, persist them via DAO, and audit creation while enforcing admin role.
- Verify invite tokens on acceptance, add users to organization membership, consume invites, and log audits.
- Cover invite flows with tests for role enforcement, persistence, and membership insertion.

## Testing
- `lein test` *(fails: Could not transfer artifacts through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c3874069e883208c00c7f389a12aea