### PR TITLE
Persist active org selection and enforce membership

### DIFF
--- a/src/etlp_mapper/handler/me.clj
+++ b/src/etlp_mapper/handler/me.clj
@@ -1,12 +1,21 @@
 (ns etlp-mapper.handler.me
   (:require [ataraxy.response :as response]
+            [clojure.java.jdbc :as jdbc]
             [integrant.core :as ig]))
 
 ;; POST /me/active-org – set the currently active organisation for the user.
-;; The real implementation would persist this choice and perhaps issue a new
-;; token.  Here we simply echo back the requested organisation identifier.
+;; Validates that the authenticated user is a member of the organisation and
+;; persists the choice by updating `users.last_used_org_id`.
 (defmethod ig/init-key :etlp-mapper.handler.me/set-active-org
-  [_ _]
-  (fn [{{:keys [org_id]} :body-params}]
-    [::response/ok {:org_id org_id}]))
+  [_ {:keys [db]}]
+  (fn [{{:keys [org_id]} :body-params :as request}]
+    (let [user-id (get-in request [:identity :user :id])
+          member? (seq (jdbc/query (:spec db)
+                                   ["select 1 from organization_members where organization_id = ? and user_id = ? limit 1"
+                                    org_id user-id]))]
+      (if member?
+        (do
+          (jdbc/update! (:spec db) :users {:last_used_org_id org_id} ["id = ?" user-id])
+          [::response/ok {:org_id org_id}])
+        [::response/forbidden {:error "Organization access denied"}]))))
 

--- a/test/etlp_mapper/handler/me_test.clj
+++ b/test/etlp_mapper/handler/me_test.clj
@@ -1,0 +1,29 @@
+(ns etlp-mapper.handler.me-test
+  (:require [clojure.test :refer :all]
+            [clojure.java.jdbc :as jdbc]
+            [integrant.core :as ig]
+            [ataraxy.response :as response]
+            ;; ensure handler namespace is loaded for init-key method
+            [etlp-mapper.handler.me]))
+
+(deftest set-active-org-persists-last-used-org-id
+  (let [update-capture (atom nil)
+        handler (ig/init-key :etlp-mapper.handler.me/set-active-org {:db {:spec ::db}})]
+    (with-redefs [jdbc/query (fn [_ _] [{:organization_id "org-1"}])
+                  jdbc/update! (fn [& args] (reset! update-capture args))]
+      (let [resp (handler {:identity {:user {:id 1}}
+                           :body-params {:org_id "org-1"}})]
+        (is (= [::response/ok {:org_id "org-1"}] resp))
+        (is (= [::db :users {:last_used_org_id "org-1"} ["id = ?" 1]]
+               @update-capture))))))
+
+(deftest set-active-org-forbidden-when-not-member
+  (let [update-called? (atom false)
+        handler (ig/init-key :etlp-mapper.handler.me/set-active-org {:db {:spec ::db}})]
+    (with-redefs [jdbc/query (fn [_ _] [])
+                  jdbc/update! (fn [& _] (reset! update-called? true))]
+      (let [resp (handler {:identity {:user {:id 1}}
+                           :body-params {:org_id "org-1"}})]
+        (is (= ::response/forbidden (first resp)))
+        (is (false? @update-called?))))))
+


### PR DESCRIPTION
## Summary
- update `/me/active-org` handler to verify membership and persist the chosen organization
- add tests for persisting last used org and denying access without membership

## Testing
- `lein test`

------
https://chatgpt.com/codex/tasks/task_e_68c38740ed348320b49bba947f05df7a