### PR TITLE
Enforce organization scoping and add isolation tests

### DIFF
--- a/src/etlp_mapper/ai_usage_logs.clj
+++ b/src/etlp_mapper/ai_usage_logs.clj
@@ -4,8 +4,8 @@
             duct.database.sql))
 
 (defprotocol AIUsageLogs
-  (find-usage [db id]
-    "Find a usage record by id.")
+  (find-usage [db org-id id]
+    "Find a usage record by id scoped to an organization.")
   (find-usage-for-org [db org-id]
     "List usage records for an organization.")
   (log-usage [db data]
@@ -13,8 +13,9 @@
 
 (extend-protocol AIUsageLogs
   duct.database.sql.Boundary
-  (find-usage [{db :spec} id]
-    (first (jdbc/query db ["select * from ai_usage_logs where id = ?" id])))
+  (find-usage [{db :spec} org-id id]
+    (first (jdbc/query db
+                       ["select * from ai_usage_logs where id = ? and organization_id = ?" id org-id])))
   (find-usage-for-org [{db :spec} org-id]
     (jdbc/query db ["select * from ai_usage_logs where organization_id = ?" org-id]))
   (log-usage [{db :spec} data]

--- a/src/etlp_mapper/ai_usage_logs.clj
+++ b/src/etlp_mapper/ai_usage_logs.clj
@@ -11,15 +11,24 @@
   (log-usage [db data]
     "Insert a new usage record."))
 
+(defn- find-usage* [db org-id id]
+  (first (jdbc/query db
+                     ["select * from ai_usage_logs where id = ? and organization_id = ?" id org-id])))
+
+(defn- find-usage-for-org* [db org-id]
+  (jdbc/query db ["select * from ai_usage_logs where organization_id = ?" org-id]))
+
+(defn- log-usage* [db data]
+  (first (jdbc/insert! db :ai_usage_logs data)))
+
 (extend-protocol AIUsageLogs
   duct.database.sql.Boundary
   (find-usage [{db :spec} org-id id]
-    (first (jdbc/query db
-                       ["select * from ai_usage_logs where id = ? and organization_id = ?" id org-id])))
+    (find-usage* db org-id id))
   (find-usage-for-org [{db :spec} org-id]
-    (jdbc/query db ["select * from ai_usage_logs where organization_id = ?" org-id]))
+    (find-usage-for-org* db org-id))
   (log-usage [{db :spec} data]
-    (first (jdbc/insert! db :ai_usage_logs data))))
+    (log-usage* db data)))
 
 
 (defn log!

--- a/src/etlp_mapper/audit_logs.clj
+++ b/src/etlp_mapper/audit_logs.clj
@@ -11,15 +11,24 @@
   (create-log [db data]
     "Insert a new audit log entry."))
 
+(defn- find-log* [db org-id id]
+  (first (jdbc/query db
+                     ["select * from audit_logs where id = ? and organization_id = ?" id org-id])))
+
+(defn- find-logs* [db org-id]
+  (jdbc/query db ["select * from audit_logs where organization_id = ? order by created_at desc" org-id]))
+
+(defn- create-log* [db data]
+  (first (jdbc/insert! db :audit_logs data)))
+
 (extend-protocol AuditLogs
   duct.database.sql.Boundary
   (find-log [{db :spec} org-id id]
-    (first (jdbc/query db
-                       ["select * from audit_logs where id = ? and organization_id = ?" id org-id])))
+    (find-log* db org-id id))
   (find-logs [{db :spec} org-id]
-    (jdbc/query db ["select * from audit_logs where organization_id = ? order by created_at desc" org-id]))
+    (find-logs* db org-id))
   (create-log [{db :spec} data]
-    (first (jdbc/insert! db :audit_logs data))))
+    (create-log* db data)))
 
 
 (defn log!

--- a/src/etlp_mapper/audit_logs.clj
+++ b/src/etlp_mapper/audit_logs.clj
@@ -4,8 +4,8 @@
             duct.database.sql))
 
 (defprotocol AuditLogs
-  (find-log [db id]
-    "Find a log entry by id.")
+  (find-log [db org-id id]
+    "Find a log entry by id scoped to an organization.")
   (find-logs [db org-id]
     "List log entries for an organization.")
   (create-log [db data]
@@ -13,8 +13,9 @@
 
 (extend-protocol AuditLogs
   duct.database.sql.Boundary
-  (find-log [{db :spec} id]
-    (first (jdbc/query db ["select * from audit_logs where id = ?" id])))
+  (find-log [{db :spec} org-id id]
+    (first (jdbc/query db
+                       ["select * from audit_logs where id = ? and organization_id = ?" id org-id])))
   (find-logs [{db :spec} org-id]
     (jdbc/query db ["select * from audit_logs where organization_id = ? order by created_at desc" org-id]))
   (create-log [{db :spec} data]

--- a/src/etlp_mapper/auth.clj
+++ b/src/etlp_mapper/auth.clj
@@ -117,7 +117,8 @@
                                 #{})))
                   identity {:user {:id (:id user)
                                    :email (:email user)
-                                   :idp-sub (:idp_sub user)}
+                                   :idp-sub (:idp_sub user)
+                                   :last-used-org-id (:last_used_org_id user)}
                             :org/id org-id
                             :roles roles}
                   resp    (handler (assoc req :identity identity))]

--- a/src/etlp_mapper/handler/billing.clj
+++ b/src/etlp_mapper/handler/billing.clj
@@ -10,8 +10,13 @@
 (defmethod ig/init-key :etlp-mapper.handler.billing/portal
   [_ _]
   (fn [request]
-    (let [roles (get-in request [:identity :claims :roles])]
-      (if (admin-role? roles)
-        [::response/ok {:url "https://billing.example.com/portal"}]
+    (let [roles  (get-in request [:identity :claims :roles])
+          org-id (get-in request [:identity :org/id])]
+      (cond
+        (nil? org-id)
+        [::response/forbidden {:error "Organization context required"}]
+        (admin-role? roles)
+        [::response/ok {:url "https://billing.example.com/portal" :org_id org-id}]
+        :else
         [::response/forbidden {:error "Insufficient role"}]))))
 

--- a/src/etlp_mapper/handler/billing.clj
+++ b/src/etlp_mapper/handler/billing.clj
@@ -10,7 +10,7 @@
 (defmethod ig/init-key :etlp-mapper.handler.billing/portal
   [_ _]
   (fn [request]
-    (let [roles  (get-in request [:identity :claims :roles])
+    (let [roles  (get-in request [:identity :roles])
           org-id (get-in request [:identity :org/id])]
       (cond
         (nil? org-id)

--- a/src/etlp_mapper/handler/mappings.clj
+++ b/src/etlp_mapper/handler/mappings.clj
@@ -50,7 +50,7 @@
 (defmethod ig/init-key :etlp-mapper.handler/apply-mappings [_ {:keys [db]}]
   (fn [{[_ id data] :ataraxy/result :as request}]
     (let [org-id (get-in request [:identity :org/id])
-          user-id (get-in request [:identity :claims :sub])]
+          user-id (get-in request [:identity :user :id])]
       (if (nil? org-id)
         [::response/forbidden {:error "Organization context required"}]
         (try
@@ -70,7 +70,7 @@
 (defmethod ig/init-key :etlp-mapper.handler.mappings [_ {:keys [db]}]
   (fn [request]
     (let [org-id (get-in request [:identity :org/id])
-          user-id (get-in request [:identity :claims :sub])]
+          user-id (get-in request [:identity :user :id])]
       (if (nil? org-id)
         [::response/forbidden {:error "Organization context required"}]
         (try

--- a/src/etlp_mapper/handler/mappings.clj
+++ b/src/etlp_mapper/handler/mappings.clj
@@ -51,32 +51,36 @@
   (fn [{[_ id data] :ataraxy/result :as request}]
     (let [org-id (get-in request [:identity :org/id])
           user-id (get-in request [:identity :claims :sub])]
-      (try
-        (let [translated (apply-mapping db org-id id data)]
-          (audit-logs/log! db {:org-id org-id
-                               :user-id user-id
-                               :action "apply-mapping"
-                               :context {:mapping-id id}})
-          (ai-usage-logs/log! db {:org-id org-id
-                                  :user-id user-id
-                                  :feature-type "transform"})
-          [::response/ok {:result translated :org/id org-id}])
-        (catch Exception e
-          (println e)
-          [::response/bad-request {:error (str e)}])))))
+      (if (nil? org-id)
+        [::response/forbidden {:error "Organization context required"}]
+        (try
+          (let [translated (apply-mapping db org-id id data)]
+            (audit-logs/log! db {:org-id org-id
+                                 :user-id user-id
+                                 :action "apply-mapping"
+                                 :context {:mapping-id id}})
+            (ai-usage-logs/log! db {:org-id org-id
+                                    :user-id user-id
+                                    :feature-type "transform"})
+            [::response/ok {:result translated :org/id org-id}])
+          (catch Exception e
+            (println e)
+            [::response/bad-request {:error (str e)}])))))
 
 (defmethod ig/init-key :etlp-mapper.handler.mappings [_ {:keys [db]}]
   (fn [request]
     (let [org-id (get-in request [:identity :org/id])
           user-id (get-in request [:identity :claims :sub])]
-      (try
-        (let [translated (create request)]
-          (pprint translated)
-          (audit-logs/log! db {:org-id org-id
-                               :user-id user-id
-                               :action "create-mapping"
-                               :context {:request (:request translated)}})
-          [::response/ok (assoc translated :org/id org-id)])
-        (catch Exception e
-          (println e)
-          [::response/bad-request {:error (.getMessage e)}])))))
+      (if (nil? org-id)
+        [::response/forbidden {:error "Organization context required"}]
+        (try
+          (let [translated (create request)]
+            (pprint translated)
+            (audit-logs/log! db {:org-id org-id
+                                 :user-id user-id
+                                 :action "create-mapping"
+                                 :context {:request (:request translated)}})
+            [::response/ok (assoc translated :org/id org-id)])
+          (catch Exception e
+            (println e)
+            [::response/bad-request {:error (.getMessage e)}]))))))

--- a/src/etlp_mapper/handler/orgs.clj
+++ b/src/etlp_mapper/handler/orgs.clj
@@ -1,7 +1,8 @@
 (ns etlp-mapper.handler.orgs
   (:require [ataraxy.response :as response]
             [integrant.core :as ig]
-            [etlp-mapper.audit-logs :as audit-logs]))
+            [etlp-mapper.audit-logs :as audit-logs]
+            [etlp-mapper.identity :as identity]))
 
 ;; Handler for creating a new organization. Requires an authenticated user
 ;; without an active organisation association. The real implementation would
@@ -11,12 +12,15 @@
 (defmethod ig/init-key :etlp-mapper.handler.orgs/create
   [_ {:keys [db]}]
   (fn [request]
-    (if (get-in request [:identity :org/id])
+    (if (identity/org-id request)
       [::response/forbidden {:error "Organization already selected"}]
       (let [new-id (str (java.util.UUID/randomUUID))
-            user-id (get-in request [:identity :user :id])]
-        (audit-logs/log! db {:org-id new-id
-                             :user-id user-id
-                             :action "create-organization"})
-        [::response/ok {:org_id new-id}]))))
+            user-id (identity/user-id request)]
+        (if (nil? user-id)
+          [::response/forbidden {:error "User context required"}]
+          (do
+            (audit-logs/log! db {:org-id new-id
+                                 :user-id user-id
+                                 :action "create-organization"})
+            [::response/ok {:org_id new-id}]))))))
 

--- a/src/etlp_mapper/handler/orgs.clj
+++ b/src/etlp_mapper/handler/orgs.clj
@@ -14,7 +14,7 @@
     (if (get-in request [:identity :org/id])
       [::response/forbidden {:error "Organization already selected"}]
       (let [new-id (str (java.util.UUID/randomUUID))
-            user-id (get-in request [:identity :claims :sub])]
+            user-id (get-in request [:identity :user :id])]
         (audit-logs/log! db {:org-id new-id
                              :user-id user-id
                              :action "create-organization"})

--- a/src/etlp_mapper/handler/whoami.clj
+++ b/src/etlp_mapper/handler/whoami.clj
@@ -5,12 +5,11 @@
 (defmethod ig/init-key :etlp-mapper.handler/whoami
   [_ _]
   (fn [request]
-    (let [claims (get-in request [:identity :claims])
-          org-id (get-in request [:identity :org/id])
-          user   {:sub   (:sub claims)
-                  :email (:email claims)
-                  :exp   (:exp claims)}]
+    (let [identity (:identity request)
+          org-id   (:org/id identity)
+          user     (some-> identity :user
+                           (select-keys [:id :email :idp-sub :last-used-org-id]))]
       [::response/ok {:user   user
                       :org_id org-id
-                      :roles (:roles claims)}])))
+                      :roles (:roles identity)}])))
 

--- a/src/etlp_mapper/handler/whoami.clj
+++ b/src/etlp_mapper/handler/whoami.clj
@@ -1,15 +1,15 @@
 (ns etlp-mapper.handler.whoami
   (:require [ataraxy.response :as response]
-            [integrant.core :as ig]))
+            [integrant.core :as ig]
+            [etlp-mapper.identity :as identity]))
 
 (defmethod ig/init-key :etlp-mapper.handler/whoami
   [_ _]
   (fn [request]
-    (let [identity (:identity request)
-          org-id   (:org/id identity)
-          user     (some-> identity :user
-                           (select-keys [:id :email :idp-sub :last-used-org-id]))]
-      [::response/ok {:user   user
+    (let [user   (identity/user request)
+          org-id (identity/org-id request)
+          roles  (identity/roles request)]
+      [::response/ok {:user   (not-empty user)
                       :org_id org-id
-                      :roles (:roles identity)}])))
+                      :roles roles}])))
 

--- a/src/etlp_mapper/identity.clj
+++ b/src/etlp_mapper/identity.clj
@@ -1,0 +1,74 @@
+(ns etlp-mapper.identity
+  "Helpers for working with the request identity map.")
+
+(defn- ->keyword
+  "Convert a role value into a keyword when possible."
+  [v]
+  (cond
+    (keyword? v) v
+    (string? v)  (keyword v)
+    :else        v))
+
+(defn org-id
+  "Return the active organization identifier from the request."
+  [request]
+  (or (get-in request [:identity :org/id])
+      (get-in request [:identity :org-id])
+      (get-in request [:identity :org_id])))
+
+(defn roles
+  "Return the set of roles associated with the authenticated identity.
+
+  Handles both the newer identity shape where roles are provided as a set of
+  keywords and the legacy structure where roles live under `:claims` as strings."
+  [request]
+  (let [raw-roles (or (get-in request [:identity :roles])
+                      (get-in request [:identity :claims :roles]))]
+    (cond
+      (nil? raw-roles) #{}
+      (set? raw-roles) (set (map ->keyword raw-roles))
+      (sequential? raw-roles) (set (map ->keyword raw-roles))
+      :else (set (keep (fn [v]
+                         (when v
+                           (->keyword v)))
+                       (if (coll? raw-roles)
+                         raw-roles
+                         [raw-roles]))))))
+
+(defn user
+  "Return a sanitized representation of the authenticated user.
+
+  The Keycloak integration stores database user information under `:user`, while
+  the legacy implementation exposed raw token claims.  This helper merges the
+  useful bits of both shapes into a single map with consistent keys."
+  [request]
+  (let [identity (:identity request)
+        user-map (when (map? identity) (:user identity))
+        claims   (when (map? identity) (:claims identity))
+        last-org (or (:last-used-org-id user-map)
+                     (:last_used_org_id user-map)
+                     (:last_used_org_id claims))
+        email    (or (:email user-map) (:email claims))
+        idp-sub  (or (:idp-sub user-map)
+                     (:idp_sub user-map)
+                     (:sub claims))]
+    (cond-> {}
+      (:id user-map) (assoc :id (:id user-map))
+      email (assoc :email email)
+      idp-sub (assoc :idp-sub idp-sub)
+      (:exp claims) (assoc :exp (:exp claims))
+      last-org (assoc :last-used-org-id last-org))))
+
+(defn user-id
+  "Extract the stable user identifier from the request identity.
+
+  Prefers the database identifier exposed by the Keycloak integration but falls
+  back to the identity provider subject when running against the legacy stack."
+  [request]
+  (or (get-in request [:identity :user :id])
+      (get-in request [:identity :user/id])
+      (get-in request [:identity :user-id])
+      (get-in request [:identity :user_id])
+      (get-in request [:identity :claims :user-id])
+      (get-in request [:identity :claims :user_id])
+      (get-in request [:identity :claims :sub]))))

--- a/src/etlp_mapper/organization_invites.clj
+++ b/src/etlp_mapper/organization_invites.clj
@@ -6,14 +6,14 @@
            (com.auth0.jwt.algorithms Algorithm)))
 
 (defprotocol OrganizationInvites
-  (find-invite [db token]
-    "Find an invite by token.")
+  (find-invite [db org-id token]
+    "Find an invite by token scoped to an organization.")
   (create-invite [db data]
     "Create a new invite record.")
   (upsert-invite [db data]
     "Insert or update an invite by token.")
-  (consume-invite [db token]
-    "Delete an invite by token."))
+  (consume-invite [db org-id token]
+    "Delete an invite by token within an organization."))
 
 (defn sign-token
   "Sign invite claims with a shared secret and return a JWT string."
@@ -40,15 +40,17 @@
 
 (extend-protocol OrganizationInvites
   duct.database.sql.Boundary
-  (find-invite [{db :spec} token]
-    (first (jdbc/query db ["select * from organization_invites where token = ?" token])))
+  (find-invite [{db :spec} org-id token]
+    (first (jdbc/query db
+                       ["select * from organization_invites where token = ? and organization_id = ?" token org-id])))
   (create-invite [{db :spec} data]
     (first (jdbc/insert! db :organization_invites data)))
-  (upsert-invite [db data]
-    (if (find-invite db (:token data))
-      (jdbc/update! (:spec db) :organization_invites (dissoc data :token)
-                    ["token = ?" (:token data)])
+  (upsert-invite [db {:keys [organization_id] :as data}]
+    (if (find-invite db organization_id (:token data))
+      (jdbc/update! (:spec db) :organization_invites (dissoc data :token :organization_id)
+                    ["token = ? and organization_id = ?" (:token data) organization_id])
       (create-invite db data)))
-  (consume-invite [{db :spec} token]
-    (jdbc/delete! db :organization_invites ["token = ?" token])))
+  (consume-invite [{db :spec} org-id token]
+    (jdbc/delete! db :organization_invites
+                  ["token = ? and organization_id = ?" token org-id])))
 

--- a/test/etlp_mapper/identity_test.clj
+++ b/test/etlp_mapper/identity_test.clj
@@ -1,0 +1,41 @@
+(ns etlp-mapper.identity-test
+  (:require [clojure.test :refer :all]
+            [etlp-mapper.identity :as identity]))
+
+(deftest org-id-extraction
+  (is (= "org-1" (identity/org-id {:identity {:org/id "org-1"}})))
+  (is (= "org-2" (identity/org-id {:identity {:org-id "org-2"}})))
+  (is (= "org-3" (identity/org-id {:identity {:org_id "org-3"}})))
+  (is (nil? (identity/org-id {}))))
+
+(deftest roles-normalization
+  (is (= #{:admin :owner}
+         (identity/roles {:identity {:roles #{:admin "owner"}}})))
+  (is (= #{:admin}
+         (identity/roles {:identity {:roles ["admin"]}})))
+  (is (= #{:viewer}
+         (identity/roles {:identity {:claims {:roles "viewer"}}})))
+  (is (empty? (identity/roles {}))))
+
+(deftest user-data-merging
+  (let [request {:identity {:user {:id "user-1"
+                                   :email "user@example.com"
+                                   :idp_sub "sub-123"
+                                   :last_used_org_id "org-1"}
+                            :claims {:email "token@example.com"
+                                     :sub "sub-123"
+                                     :exp 123}}}
+        user (identity/user request)]
+    (is (= "user-1" (:id user)))
+    (is (= "user@example.com" (:email user)))
+    (is (= "sub-123" (:idp-sub user)))
+    (is (= "org-1" (:last-used-org-id user)))
+    (is (= 123 (:exp user))))
+  (let [request {:identity {:claims {:sub "sub-456" :email "token@example.com"}}}
+        user (identity/user request)]
+    (is (= {:idp-sub "sub-456" :email "token@example.com"} user))))
+
+(deftest user-id-precedence
+  (is (= "user-1" (identity/user-id {:identity {:user {:id "user-1"}}})))
+  (is (= "legacy" (identity/user-id {:identity {:claims {:sub "legacy"}}})))
+  (is (nil? (identity/user-id {}))))

--- a/test/etlp_mapper/isolation_test.clj
+++ b/test/etlp_mapper/isolation_test.clj
@@ -153,6 +153,11 @@
                               :identity {:org/id "org-1"
                                          :roles #{:admin}
                                          :user {:id "user-1"}}}))))
+    (testing "create invite rejects missing user context"
+      (is (= [::response/forbidden {:error "User context required"}]
+             (create-handler {:ataraxy/result [::create "org-1"]
+                              :identity {:org/id "org-1"
+                                         :roles #{:admin}}}))))
     (testing "create invite rejects callers without admin role"
       (is (= [::response/forbidden {:error "Insufficient role"}]
              (create-handler {:ataraxy/result [::create "org-1"]
@@ -189,6 +194,10 @@
              (accept-handler {:body-params {:org_id "org-1"}
                               :identity {:org/id "org-1"
                                          :user {:id "user-1"}}}))))
+    (testing "accept invite rejects missing user context"
+      (is (= [::response/forbidden {:error "User context required"}]
+             (accept-handler {:body-params {:token "tok-1" :org_id "org-1"}
+                              :identity {:org/id "org-1"}}))))
     (testing "accept invite logs within the active organization"
       (let [logged (atom nil)
             [status body] (with-redefs [audit-logs/log! (fn [_ entry] (reset! logged entry))]

--- a/test/etlp_mapper/isolation_test.clj
+++ b/test/etlp_mapper/isolation_test.clj
@@ -1,53 +1,204 @@
 (ns etlp-mapper.isolation-test
-  (:require [clojure.test :refer :all]))
+  (:require [ataraxy.response :as response]
+            [clojure.java.jdbc :as jdbc]
+            [clojure.test :refer :all]
+            [integrant.core :as ig]
+            [etlp-mapper.ai-usage-logs :as ai-usage-logs]
+            [etlp-mapper.audit-logs :as audit-logs]
+            [etlp-mapper.organization-invites :as org-invites]
+            [etlp-mapper.organization-members :as org-members]
+            [etlp-mapper.organization-subscriptions :as org-subs]
+            [etlp-mapper.handler.invites]))
 
-(defonce mappings (atom {}))
-(defonce invites (atom {}))
-(defonce members (atom #{}))
-(defonce subscriptions (atom {}))
-(defonce logs (atom {}))
+(deftest invite-dao-queries-are-scoped
+  (testing "find-invite filters by organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/query (fn [_ sql] (reset! captured sql) [])]
+        (@#'org-invites/find-invite* ::spec "org-1" "tok-1"))
+      (let [[sql & params] @captured]
+        (is (re-find #"organization_id" sql))
+        (is (= ["tok-1" "org-1"] params)))))
+  (testing "consume-invite filters by organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/delete! (fn [_ _ where] (reset! captured where) 1)]
+        (@#'org-invites/consume-invite* ::spec "org-1" "tok-1"))
+      (let [[where & params] @captured]
+        (is (re-find #"organization_id" where))
+        (is (= ["tok-1" "org-1"] params)))))
+  (testing "upsert updates scoped records only"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/update! (fn [_ _ set-map where]
+                                   (reset! captured [set-map where])
+                                   [])]
+        (@#'org-invites/update-invite* ::spec {:organization_id "org-1"
+                                               :token "tok-1"
+                                               :email "e@example.com"}))
+      (let [[set-map where] @captured]
+        (is (= {:email "e@example.com"} set-map))
+        (is (re-find #"organization_id" (first where)))
+        (is (= ["tok-1" "org-1"] (rest where)))))))
 
-(use-fixtures :each (fn [f]
-                      (reset! mappings {1 {:org-id "org-1" :value "a"}
-                                         2 {:org-id "org-2" :value "b"}})
-                      (reset! invites {"tok-1" {:org-id "org-1"}
-                                       "tok-2" {:org-id "org-2"}})
-                      (reset! members #{["org-1" "user-1"]
-                                        ["org-2" "user-2"]})
-                      (reset! subscriptions {"org-1" {:plan "basic"}
-                                             "org-2" {:plan "pro"}})
-                      (reset! logs {1 {:org-id "org-1"}
-                                    2 {:org-id "org-2"}})
-                      (f)))
+(deftest membership-dao-queries-are-scoped
+  (testing "listing members requires matching organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/query (fn [_ sql] (reset! captured sql) [])]
+        (@#'org-members/find-members* ::spec "org-1"))
+      (let [[sql & params] @captured]
+        (is (re-find #"organization_id" sql))
+        (is (= ["org-1"] params)))))
+  (testing "membership checks constrain by organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/query (fn [_ sql] (reset! captured sql) [])]
+        (is (false? (@#'org-members/member?* ::spec "org-1" "user-1"))))
+      (let [[sql & params] @captured]
+        (is (re-find #"organization_id" sql))
+        (is (= ["org-1" "user-1"] params)))))
+  (testing "role checks constrain by organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/query (fn [_ sql] (reset! captured sql) [])]
+        (is (false? (@#'org-members/has-role?* ::spec "org-1" "user-1" "admin"))))
+      (let [[sql & params] @captured]
+        (is (re-find #"organization_id" sql))
+        (is (= ["org-1" "user-1" "admin"] params)))))
+  (testing "removing members constrains by organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/delete! (fn [_ _ where] (reset! captured where) 1)]
+        (@#'org-members/remove-member* ::spec "org-1" "user-1"))
+      (let [[where & params] @captured]
+        (is (re-find #"organization_id" where))
+        (is (= ["org-1" "user-1"] params))))))
 
-(defn fetch [org-id id]
-  (let [row (get @mappings id)]
-    (when (= org-id (:org-id row)) row)))
+(deftest subscription-dao-queries-are-scoped
+  (testing "subscription lookups are organization scoped"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/query (fn [_ sql] (reset! captured sql) [])]
+        (@#'org-subs/find-subscription* ::spec "org-1"))
+      (let [[sql & params] @captured]
+        (is (re-find #"organization_id" sql))
+        (is (= ["org-1"] params)))))
+  (testing "subscription updates include organization predicate"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/update! (fn [_ _ data where]
+                                   (reset! captured [data where])
+                                   [])]
+        (@#'org-subs/update-subscription* ::spec "org-1" {:plan "pro"}))
+      (let [[data where] @captured]
+        (is (= {:plan "pro"} data))
+        (is (re-find #"organization_id" (first where)))
+        (is (= ["org-1"] (rest where)))))))
 
-(defn fetch-invite [org-id token]
-  (let [row (get @invites token)]
-    (when (= org-id (:org-id row)) row)))
+(deftest log-dao-queries-are-scoped
+  (testing "audit log lookup filters by organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/query (fn [_ sql] (reset! captured sql) [])]
+        (@#'audit-logs/find-log* ::spec "org-1" 1))
+      (let [[sql & params] @captured]
+        (is (re-find #"organization_id" sql))
+        (is (= [1 "org-1"] params)))))
+  (testing "audit log listings filter by organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/query (fn [_ sql] (reset! captured sql) [])]
+        (@#'audit-logs/find-logs* ::spec "org-1"))
+      (let [[sql & params] @captured]
+        (is (re-find #"organization_id" sql))
+        (is (= ["org-1"] params)))))
+  (testing "ai usage lookup filters by organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/query (fn [_ sql] (reset! captured sql) [])]
+        (@#'ai-usage-logs/find-usage* ::spec "org-1" 1))
+      (let [[sql & params] @captured]
+        (is (re-find #"organization_id" sql))
+        (is (= [1 "org-1"] params)))))
+  (testing "ai usage listings filter by organization"
+    (let [captured (atom nil)]
+      (with-redefs [jdbc/query (fn [_ sql] (reset! captured sql) [])]
+        (@#'ai-usage-logs/find-usage-for-org* ::spec "org-1"))
+      (let [[sql & params] @captured]
+        (is (re-find #"organization_id" sql))
+        (is (= ["org-1"] params)))))
+  (testing "audit log writes include organization context"
+    (let [captured (atom nil)]
+      (with-redefs [audit-logs/create-log (fn [_ data] (reset! captured data))]
+        (audit-logs/log! ::db {:org-id "org-1"
+                               :user-id "user-1"
+                               :action "login"
+                               :context {:ip "127.0.0.1"}}))
+      (is (= "org-1" (:organization_id @captured)))
+      (is (= "user-1" (:user_id @captured)))
+      (is (re-find #"ip" (:context @captured)))))
+  (testing "ai usage writes include organization context"
+    (let [captured (atom nil)]
+      (with-redefs [ai-usage-logs/log-usage (fn [_ data] (reset! captured data))]
+        (ai-usage-logs/log! ::db {:org-id "org-1"
+                                  :user-id "user-1"
+                                  :feature-type "transform"
+                                  :input-tokens 10
+                                  :output-tokens 5}))
+      (is (= "org-1" (:organization_id @captured)))
+      (is (= "user-1" (:user_id @captured)))
+      (is (= "transform" (:feature_type @captured))))))
 
-(defn member? [org-id user-id]
-  (contains? @members [org-id user-id]))
-
-(defn fetch-sub [org-id target-org]
-  (when (= org-id target-org)
-    (get @subscriptions target-org)))
-
-(defn fetch-log [org-id id]
-  (let [row (get @logs id)]
-    (when (= org-id (:org-id row)) row)))
-
-(deftest disallow-cross-org-access
-  (is (nil? (fetch "org-1" 2)))
-  (is (= {:org-id "org-1" :value "a"} (fetch "org-1" 1)))
-  (is (nil? (fetch-invite "org-1" "tok-2")))
-  (is (= {:org-id "org-1"} (fetch-invite "org-1" "tok-1")))
-  (is (false? (member? "org-1" "user-2")))
-  (is (true? (member? "org-1" "user-1")))
-  (is (nil? (fetch-sub "org-1" "org-2")))
-  (is (= {:plan "basic"} (fetch-sub "org-1" "org-1")))
-  (is (nil? (fetch-log "org-1" 2)))
-  (is (= {:org-id "org-1"} (fetch-log "org-1" 1))))
-
+(deftest invite-handlers-require-organization-context
+  (let [create-handler (ig/init-key :etlp-mapper.handler.invites/create {:db ::db})
+        accept-handler (ig/init-key :etlp-mapper.handler.invites/accept {:db ::db})]
+    (testing "create invite rejects missing organization"
+      (is (= [::response/forbidden {:error "Organization context required"}]
+             (create-handler {:ataraxy/result [::create "org-1"]
+                              :identity {:org/id nil
+                                         :roles #{:admin}
+                                         :user {:id "user-1"}}}))))
+    (testing "create invite rejects organization mismatches"
+      (is (= [::response/forbidden {:error "Organization mismatch"}]
+             (create-handler {:ataraxy/result [::create "org-2"]
+                              :identity {:org/id "org-1"
+                                         :roles #{:admin}
+                                         :user {:id "user-1"}}}))))
+    (testing "create invite rejects callers without admin role"
+      (is (= [::response/forbidden {:error "Insufficient role"}]
+             (create-handler {:ataraxy/result [::create "org-1"]
+                              :identity {:org/id "org-1"
+                                         :roles #{:member}
+                                         :user {:id "user-1"}}}))))
+    (testing "create invite logs scoped token issuance"
+      (let [logged (atom nil)
+            [status body] (with-redefs [audit-logs/log! (fn [_ entry] (reset! logged entry))]
+                             (create-handler {:ataraxy/result [::create "org-1"]
+                                              :identity {:org/id "org-1"
+                                                         :roles #{:admin}
+                                                         :user {:id "user-1"}}}))]
+        (is (= ::response/ok status))
+        (is (= "org-1" (:org_id body)))
+        (is (string? (:token body)))
+        (is (= {:org-id "org-1"
+                :user-id "user-1"
+                :action "create-invite"
+                :context {:token (:token body)}}
+               @logged))))
+    (testing "accept invite rejects missing organization context"
+      (is (= [::response/forbidden {:error "Organization context required"}]
+             (accept-handler {:body-params {:token "tok-1"}
+                              :identity {:org/id nil
+                                         :user {:id "user-1"}}}))))
+    (testing "accept invite rejects mismatched body organization"
+      (is (= [::response/forbidden {:error "Organization mismatch"}]
+             (accept-handler {:body-params {:token "tok-1" :org_id "org-2"}
+                              :identity {:org/id "org-1"
+                                         :user {:id "user-1"}}}))))
+    (testing "accept invite requires a token"
+      (is (= [::response/bad-request {:error "Invalid token"}]
+             (accept-handler {:body-params {:org_id "org-1"}
+                              :identity {:org/id "org-1"
+                                         :user {:id "user-1"}}}))))
+    (testing "accept invite logs within the active organization"
+      (let [logged (atom nil)
+            [status body] (with-redefs [audit-logs/log! (fn [_ entry] (reset! logged entry))]
+                             (accept-handler {:body-params {:token "tok-1" :org_id "org-1"}
+                                              :identity {:org/id "org-1"
+                                                         :user {:id "user-1"}}}))]
+        (is (= ::response/ok status))
+        (is (= {:org_id "org-1" :token "tok-1" :status "accepted"} body))
+        (is (= {:org-id "org-1"
+                :user-id "user-1"
+                :action "accept-invite"
+                :context {:token "tok-1"}}
+               @logged))))))

--- a/test/etlp_mapper/isolation_test.clj
+++ b/test/etlp_mapper/isolation_test.clj
@@ -2,17 +2,52 @@
   (:require [clojure.test :refer :all]))
 
 (defonce mappings (atom {}))
+(defonce invites (atom {}))
+(defonce members (atom #{}))
+(defonce subscriptions (atom {}))
+(defonce logs (atom {}))
 
 (use-fixtures :each (fn [f]
                       (reset! mappings {1 {:org-id "org-1" :value "a"}
                                          2 {:org-id "org-2" :value "b"}})
+                      (reset! invites {"tok-1" {:org-id "org-1"}
+                                       "tok-2" {:org-id "org-2"}})
+                      (reset! members #{["org-1" "user-1"]
+                                        ["org-2" "user-2"]})
+                      (reset! subscriptions {"org-1" {:plan "basic"}
+                                             "org-2" {:plan "pro"}})
+                      (reset! logs {1 {:org-id "org-1"}
+                                    2 {:org-id "org-2"}})
                       (f)))
 
 (defn fetch [org-id id]
   (let [row (get @mappings id)]
     (when (= org-id (:org-id row)) row)))
 
+(defn fetch-invite [org-id token]
+  (let [row (get @invites token)]
+    (when (= org-id (:org-id row)) row)))
+
+(defn member? [org-id user-id]
+  (contains? @members [org-id user-id]))
+
+(defn fetch-sub [org-id target-org]
+  (when (= org-id target-org)
+    (get @subscriptions target-org)))
+
+(defn fetch-log [org-id id]
+  (let [row (get @logs id)]
+    (when (= org-id (:org-id row)) row)))
+
 (deftest disallow-cross-org-access
   (is (nil? (fetch "org-1" 2)))
-  (is (= {:org-id "org-1" :value "a"} (fetch "org-1" 1))))
+  (is (= {:org-id "org-1" :value "a"} (fetch "org-1" 1)))
+  (is (nil? (fetch-invite "org-1" "tok-2")))
+  (is (= {:org-id "org-1"} (fetch-invite "org-1" "tok-1")))
+  (is (false? (member? "org-1" "user-2")))
+  (is (true? (member? "org-1" "user-1")))
+  (is (nil? (fetch-sub "org-1" "org-2")))
+  (is (= {:plan "basic"} (fetch-sub "org-1" "org-1")))
+  (is (nil? (fetch-log "org-1" 2)))
+  (is (= {:org-id "org-1"} (fetch-log "org-1" 1))))
 


### PR DESCRIPTION
## Summary
- scope invite, audit log, and AI usage queries by `organization_id`
- require active organization in invite, billing, and mapping handlers
- extend isolation tests to cover invites, memberships, subscriptions, and logs

## Testing
- `lein test`

------
https://chatgpt.com/codex/tasks/task_e_68c38741eb708320bc62b92797986264