### PR TITLE
Add role-based route middleware

### DIFF
--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -12,8 +12,6 @@
 
  :etlp-mapper.auth-component/require-org {}
 
- :etlp-mapper.auth-component/require-role {}
-
  :etlp-mapper.invite/token
  {:app-secret #duct/env ["APP_SECRET" :or "dev-secret"]
   :invite-ttl-days #duct/env ["INVITE_TTL_DAYS" :or 7]}}

--- a/resources/etlp_mapper/config.edn
+++ b/resources/etlp_mapper/config.edn
@@ -2,33 +2,36 @@
  {:duct.core/project-ns etlp-mapper
 
   :duct.router/ataraxy
-  {:routes {[:get "/"] [:etlp-mapper.handler/index]
+  {:middleware {:editor        #ig/ref :etlp-mapper.auth-component/require-editor
+                :admin         #ig/ref :etlp-mapper.auth-component/require-admin
+                :owner         #ig/ref :etlp-mapper.auth-component/require-owner
+                :admin-or-owner #ig/ref :etlp-mapper.auth-component/require-admin-or-owner}
+   :routes {[:get "/"] [:etlp-mapper.handler/index]
             [:get "/whoami"] [:etlp-mapper.handler/whoami]
-            [:post "/orgs"] [:etlp-mapper.handler.orgs/create]
-            [:post "/orgs/" org-id "/invites"] [:etlp-mapper.handler.invites/create org-id]
+            [:post "/orgs"] ^:owner [:etlp-mapper.handler.orgs/create]
+            [:post "/orgs/" org-id "/invites"] ^:admin-or-owner [:etlp-mapper.handler.invites/create org-id]
             [:post "/invites/accept"] [:etlp-mapper.handler.invites/accept]
-            [:post "/me/active-org"] [:etlp-mapper.handler.me/set-active-org]
-            [:post "/billing/portal"] [:etlp-mapper.handler.billing/portal]
-            [:get "/mappings"] [:etlp-mapper.handler.mappings/list]
+            [:post "/me/active-org"] ^:admin [:etlp-mapper.handler.me/set-active-org]
+            [:post "/billing/portal"] ^:admin-or-owner [:etlp-mapper.handler.billing/portal]
+            [:get "/mappings"] ^:editor [:etlp-mapper.handler.mappings/list]
             [:post "/mappings" {{:keys [title content]} :body-params}]
-            [:etlp-mapper.handler.mappings/create title content]
+            ^:editor [:etlp-mapper.handler.mappings/create title content]
 
             [:put "/mappings/" id {{:keys [content]} :body-params}]
-            [:etlp-mapper.handler.mappings/update ^int id content]
+            ^:editor [:etlp-mapper.handler.mappings/update ^int id content]
 
             [:post "/mappings/" id "/apply" {{:keys [data]} :body-params}]
-            [:etlp-mapper.handler/apply-mappings ^int id data]
+            ^:editor [:etlp-mapper.handler/apply-mappings ^int id data]
 
             [:post "/mappings/test"]
-            [:etlp-mapper.handler.mappings]
+            ^:editor [:etlp-mapper.handler.mappings]
 
-            [:get    "/mappings/" id] [:etlp-mapper.handler.mappings/find ^int id]
-            [:get    "/mappings/" id "/_history"] [:etlp-mapper.handler.mappings/history ^int id]
-            [:get    "/mappings/" id "/_history/" version] [:etlp-mapper.handler.mappings/traverse-history ^int id version]
-            [:delete "/mappings/" id] [:etlp-mapper.handler.mappings/destroy ^int id]}}
+            [:get    "/mappings/" id] ^:editor [:etlp-mapper.handler.mappings/find ^int id]
+            [:get    "/mappings/" id "/_history"] ^:editor [:etlp-mapper.handler.mappings/history ^int id]
+            [:get    "/mappings/" id "/_history/" version] ^:editor [:etlp-mapper.handler.mappings/traverse-history ^int id version]
+            [:delete "/mappings/" id] ^:editor [:etlp-mapper.handler.mappings/destroy ^int id]}}
 
   :duct.handler/root {:middleware [#ig/ref :etlp-mapper.auth-component/require-org
-                                   #ig/ref :etlp-mapper.auth-component/require-role
                                    #ig/ref :etlp-mapper.auth-component/auth
                                    #ig/ref :etlp-mapper.middlewares/cors]}
 
@@ -133,6 +136,10 @@ $$ LANGUAGE plpgsql;"]
    :sql ["SELECT * FROM mappings WHERE organization_id = ?::uuid" org-id]
    :hrefs {:href "/mappings/{id}"}}
 
+  :etlp-mapper.auth-component/require-owner {}
+  :etlp-mapper.auth-component/require-admin {}
+  :etlp-mapper.auth-component/require-editor {}
+  :etlp-mapper.auth-component/require-admin-or-owner {}
   :etlp-mapper.middlewares/cors
   {}
 

--- a/src/etlp_mapper/auth.clj
+++ b/src/etlp_mapper/auth.clj
@@ -2,10 +2,11 @@
   "Ring middleware for validating Keycloak OIDC access tokens and
   enriching the request with database backed user and organization
   context."
-  (:require [cheshire.core :as json]
-            [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
-            [ring.util.http-response :as http])
+   (:require [cheshire.core :as json]
+             [clojure.java.jdbc :as jdbc]
+             [clojure.set :as set]
+             [clojure.string :as str]
+             [ring.util.http-response :as http])
   (:import (com.auth0.jwt JWT)
            (com.auth0.jwt.algorithms Algorithm)
            (com.auth0.jwk JwkProviderBuilder)
@@ -139,17 +140,28 @@
          (handler req)
          (forbidden "Organization context required"))))))
 
+(defn require-any-role
+  "Middleware factory enforcing that the authenticated identity has at
+  least one of the roles in `roles`."
+  [roles]
+  (fn [handler]
+    (fn [req]
+      (let [assigned (get-in req [:identity :roles])
+            required (set (map keyword roles))]
+        (if (seq (set/intersection assigned required))
+          (handler req)
+          (forbidden "Insufficient role"))))))
+
 (defn require-role
   "Middleware factory enforcing that the authenticated identity has the
   given role, using roles resolved from the database."
   [role]
-  (fn [handler]
-    (fn [req]
-      (let [roles (get-in req [:identity :roles])
-            role  (keyword role)]
-        (if (contains? roles role)
-          (handler req)
-          (forbidden "Insufficient role"))))))
+  (require-any-role [role]))
+
+(defn require-admin-or-owner
+  "Middleware allowing access to admins or owners."
+  []
+  (require-any-role [:admin :owner]))
 
 ;; Public API exports
 ;; wrap-auth, wrap-require-org and require-role

--- a/src/etlp_mapper/auth_component.clj
+++ b/src/etlp_mapper/auth_component.clj
@@ -15,3 +15,19 @@
   [_ {:keys [role]}]
   (auth/require-role role))
 
+(defmethod ig/init-key :etlp-mapper.auth-component/require-editor
+  [_ _]
+  (auth/require-role :editor))
+
+(defmethod ig/init-key :etlp-mapper.auth-component/require-admin
+  [_ _]
+  (auth/require-role :admin))
+
+(defmethod ig/init-key :etlp-mapper.auth-component/require-owner
+  [_ _]
+  (auth/require-role :owner))
+
+(defmethod ig/init-key :etlp-mapper.auth-component/require-admin-or-owner
+  [_ _]
+  (auth/require-admin-or-owner))
+

--- a/src/etlp_mapper/handler/billing.clj
+++ b/src/etlp_mapper/handler/billing.clj
@@ -2,16 +2,8 @@
   (:require [ataraxy.response :as response]
             [integrant.core :as ig]))
 
-(defn- admin-role? [roles]
-  (some #{:owner "owner" :admin "admin"} roles))
-
-;; POST /billing/portal – return a stubbed billing portal URL for owners or
-;; administrators of the active organisation.
+;; POST /billing/portal – return a stubbed billing portal URL.
 (defmethod ig/init-key :etlp-mapper.handler.billing/portal
   [_ _]
-  (fn [request]
-    (let [roles (get-in request [:identity :claims :roles])]
-      (if (admin-role? roles)
-        [::response/ok {:url "https://billing.example.com/portal"}]
-        [::response/forbidden {:error "Insufficient role"}]))))
-
+  (fn [_]
+    [::response/ok {:url "https://billing.example.com/portal"}]))

--- a/src/etlp_mapper/handler/invites.clj
+++ b/src/etlp_mapper/handler/invites.clj
@@ -3,25 +3,18 @@
             [integrant.core :as ig]
             [etlp-mapper.audit-logs :as audit-logs]))
 
-(defn- admin-role? [roles]
-  (some #{:owner "owner" :admin "admin"} roles))
-
-;; POST /orgs/:org-id/invites – create an invite token.  Requires the caller to
-;; have an admin or owner role within the organisation.  Token generation and
+;; POST /orgs/:org-id/invites – create an invite token. Token generation and
 ;; persistence are stubbed out.
 (defmethod ig/init-key :etlp-mapper.handler.invites/create
   [_ {:keys [db]}]
   (fn [{[_ org-id] :ataraxy/result :as request}]
-    (let [roles (get-in request [:identity :claims :roles])]
-      (if (admin-role? roles)
-        (let [token (str (java.util.UUID/randomUUID))
-              user-id (get-in request [:identity :claims :sub])]
-          (audit-logs/log! db {:org-id org-id
-                               :user-id user-id
-                               :action "create-invite"
-                               :context {:token token}})
-          [::response/ok {:org_id org-id :token token}])
-        [::response/forbidden {:error "Insufficient role"}]))))
+    (let [token (str (java.util.UUID/randomUUID))
+          user-id (get-in request [:identity :claims :sub])]
+      (audit-logs/log! db {:org-id org-id
+                           :user-id user-id
+                           :action "create-invite"
+                           :context {:token token}})
+      [::response/ok {:org_id org-id :token token}])))
 
 ;; POST /invites/accept – accept an invite token.  In a full system the token
 ;; would be validated and the user added to the organisation along with an

--- a/test/etlp_mapper/mapping_operations_test.clj
+++ b/test/etlp_mapper/mapping_operations_test.clj
@@ -6,14 +6,15 @@
 (defn create-handler [req]
   (http/ok {:org/id (get-in req [:identity :org/id])}))
 
+
 (deftest mapping-create-requires-role
-  (let [app ((auth/require-role :mapper) create-handler)
-        resp (app {:identity {:org/id "org-1" :roles #{:mapper}}})]
+  (let [app ((auth/require-role :editor) create-handler)
+        resp (app {:identity {:org/id "org-1" :roles #{:editor}}})]
     (is (= 200 (:status resp)))
     (is (= "org-1" (get-in resp [:body :org/id])))))
 
 (deftest mapping-create-role-forbidden
-  (let [app ((auth/require-role :mapper) create-handler)
-        resp (app {:identity {:org/id "org-1" :roles #{:viewer}}})]
+  (let [app ((auth/require-role :editor) create-handler)
+        resp (app {:identity {:org/id "org-1" :roles #{:admin}}})]
     (is (= 403 (:status resp)))))
 

--- a/test/etlp_mapper/route_roles_test.clj
+++ b/test/etlp_mapper/route_roles_test.clj
@@ -1,0 +1,38 @@
+(ns etlp-mapper.route-roles-test
+  (:require [clojure.test :refer :all]
+            [ring.util.http-response :as http]
+            [etlp-mapper.auth :as auth]))
+
+(def ok-handler (fn [_] (http/ok)))
+
+(deftest orgs-create-owner-only
+  (let [app ((auth/require-role :owner) ok-handler)
+        allowed (app {:identity {:roles #{:owner}}})
+        denied (app {:identity {:roles #{:admin}}})]
+    (is (= 200 (:status allowed)))
+    (is (= 403 (:status denied)))))
+
+(deftest set-active-org-admin-only
+  (let [app ((auth/require-role :admin) ok-handler)
+        allowed (app {:identity {:roles #{:admin}}})
+        denied (app {:identity {:roles #{:editor}}})]
+    (is (= 200 (:status allowed)))
+    (is (= 403 (:status denied)))))
+
+(deftest invites-create-admin-or-owner
+  (let [app ((auth/require-any-role [:admin :owner]) ok-handler)
+        admin-resp (app {:identity {:roles #{:admin}}})
+        owner-resp (app {:identity {:roles #{:owner}}})
+        denied (app {:identity {:roles #{:editor}}})]
+    (is (= 200 (:status admin-resp)))
+    (is (= 200 (:status owner-resp)))
+    (is (= 403 (:status denied)))))
+
+(deftest billing-portal-admin-or-owner
+  (let [app ((auth/require-any-role [:admin :owner]) ok-handler)
+        admin-resp (app {:identity {:roles #{:admin}}})
+        owner-resp (app {:identity {:roles #{:owner}}})
+        denied (app {:identity {:roles #{:editor}}})]
+    (is (= 200 (:status admin-resp)))
+    (is (= 200 (:status owner-resp)))
+    (is (= 403 (:status denied)))))


### PR DESCRIPTION
## Summary
- enforce role-based authorization via new middleware helpers
- secure routes with editor, admin, owner and combined role metadata
- test role access for organization, mapping, billing and invite endpoints

## Testing
- `lein test`


------
https://chatgpt.com/codex/tasks/task_e_68c38743603c8320b65ad95485fe835b