### PR TITLE
Improve audit and AI usage logging coverage

### DIFF
--- a/resources/etlp_mapper/config.edn
+++ b/resources/etlp_mapper/config.edn
@@ -46,7 +46,9 @@
                 #ig/ref :etlp-mapper.migration/insert-mapping-history
                 #ig/ref :etlp-mapper.migration/insert_mapping_history_trigger
                 #ig/ref :etlp-mapper.migration/updated-at-trigger
-                #ig/ref :etlp-mapper.migration/updated-mapping-trigger]}
+                #ig/ref :etlp-mapper.migration/updated-mapping-trigger
+                #ig/ref :etlp-mapper.migration/audit-log-mappings-fn
+                #ig/ref :etlp-mapper.migration/audit-log-mappings-trigger]}
 
   ; Core tables
   [:duct.migrator.ragtime/sql :etlp-mapper.migration/create-organizations]
@@ -125,6 +127,14 @@ $$ LANGUAGE plpgsql;"]
   {:up ["CREATE TRIGGER update_mapping_changetimestamp BEFORE UPDATE ON mappings FOR EACH ROW EXECUTE PROCEDURE update_changetimestamp_column();"]
    :down  ["DROP TRIGGER update_mapping_changetimestamp ON mappings;"]}
 
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/audit-log-mappings-fn]
+  {:up ["CREATE OR REPLACE FUNCTION audit_log_mappings() RETURNS TRIGGER AS $$ BEGIN IF (TG_OP = 'INSERT') THEN INSERT INTO audit_logs (organization_id, action, context) VALUES (NEW.organization_id, 'mappings-insert', json_build_object('mapping_id', NEW.id)::text); RETURN NEW; ELSIF (TG_OP = 'UPDATE') THEN INSERT INTO audit_logs (organization_id, action, context) VALUES (NEW.organization_id, 'mappings-update', json_build_object('mapping_id', NEW.id)::text); RETURN NEW; ELSIF (TG_OP = 'DELETE') THEN INSERT INTO audit_logs (organization_id, action, context) VALUES (OLD.organization_id, 'mappings-delete', json_build_object('mapping_id', OLD.id)::text); RETURN OLD; END IF; END; $$ LANGUAGE plpgsql;"]
+   :down ["DROP FUNCTION audit_log_mappings;"]}
+
+  [:duct.migrator.ragtime/sql :etlp-mapper.migration/audit-log-mappings-trigger]
+  {:up ["CREATE TRIGGER audit_log_mappings_trigger AFTER INSERT OR UPDATE OR DELETE ON mappings FOR EACH ROW EXECUTE FUNCTION audit_log_mappings();"]
+   :down ["DROP TRIGGER audit_log_mappings_trigger ON mappings;"]}
+
 
 
 ;Query handlers for Rest Endpoints
@@ -155,11 +165,11 @@ $$ LANGUAGE plpgsql;"]
 
   :etlp-mapper.handler.invites/accept {:db #ig/ref :duct.database/sql}
 
-  :etlp-mapper.handler.me/set-active-org {}
+  :etlp-mapper.handler.me/set-active-org {:db #ig/ref :duct.database/sql}
 
   :etlp-mapper.handler.billing/portal {}
 
-  [:duct.handler.sql/insert :etlp-mapper.handler.mappings/create]
+  [:duct.handler.sql/insert :etlp-mapper.handler.mappings/create-sql]
   {:request {[_ title content] :ataraxy/result
              {org-id :org/id} :identity}
 
@@ -167,22 +177,34 @@ $$ LANGUAGE plpgsql;"]
    :location "mappings/{id}"
    :hrefs {:href "/mappings/{id}"}}
 
+  :etlp-mapper.handler.mappings/create
+  {:db #ig/ref :duct.database/sql
+   :handler #ig/ref [:duct.handler.sql/insert :etlp-mapper.handler.mappings/create-sql]}
+
   [:duct.handler.sql/query-one :etlp-mapper.handler.mappings/find]
   {:request {[_ id] :ataraxy/result
              {org-id :org/id} :identity}
    :sql     ["SELECT * FROM mappings WHERE id = ? AND organization_id = ?::uuid" id org-id]
    :hrefs   {:href "/mappings/{id}"}}
 
-  [:duct.handler.sql/execute :etlp-mapper.handler.mappings/destroy]
+  [:duct.handler.sql/execute :etlp-mapper.handler.mappings/destroy-sql]
   {:request {[_ id] :ataraxy/result
              {org-id :org/id} :identity}
 
    :sql     ["DELETE FROM mappings WHERE id = ? AND organization_id = ?::uuid" id org-id]}
 
-  [:duct.handler.sql/execute :etlp-mapper.handler.mappings/update]
+  :etlp-mapper.handler.mappings/destroy
+  {:db #ig/ref :duct.database/sql
+   :handler #ig/ref [:duct.handler.sql/execute :etlp-mapper.handler.mappings/destroy-sql]}
+
+  [:duct.handler.sql/execute :etlp-mapper.handler.mappings/update-sql]
   {:request {[_ id content] :ataraxy/result
              {org-id :org/id} :identity}
    :sql     ["UPDATE mappings SET content = ? WHERE id = ? AND organization_id = ?::uuid" content id org-id]}
+
+  :etlp-mapper.handler.mappings/update
+  {:db #ig/ref :duct.database/sql
+   :handler #ig/ref [:duct.handler.sql/execute :etlp-mapper.handler.mappings/update-sql]}
 
   [:duct.handler.sql/query :etlp-mapper.handler.mappings/history]
   {:request {[_ id] :ataraxy/result

--- a/src/etlp_mapper/ai_usage_logs.clj
+++ b/src/etlp_mapper/ai_usage_logs.clj
@@ -23,11 +23,13 @@
 
 (defn log!
   "Insert a new AI usage log entry. Accepts a database boundary and a map with
-  :org-id, :user-id, :feature-type, :input-tokens and :output-tokens."
+  :org-id, :user-id, :feature-type, :input-tokens and :output-tokens.  When the
+  token counts are omitted they default to zero so callers don't need to
+  provide placeholder values."
   [db {:keys [org-id user-id feature-type input-tokens output-tokens]}]
   (log-usage db {:organization_id org-id
                  :user_id user-id
                  :feature_type feature-type
-                 :input_tokens input-tokens
-                 :output_tokens output-tokens}))
+                 :input_tokens (or input-tokens 0)
+                 :output_tokens (or output-tokens 0)}))
 

--- a/src/etlp_mapper/handler/invites.clj
+++ b/src/etlp_mapper/handler/invites.clj
@@ -1,7 +1,8 @@
 (ns etlp-mapper.handler.invites
   (:require [ataraxy.response :as response]
             [integrant.core :as ig]
-            [etlp-mapper.audit-logs :as audit-logs]))
+            [etlp-mapper.audit-logs :as audit-logs]
+            [etlp-mapper.ai-usage-logs :as ai-usage-logs]))
 
 (defn- admin-role? [roles]
   (some #{:owner "owner" :admin "admin"} roles))
@@ -20,6 +21,11 @@
                                :user-id user-id
                                :action "create-invite"
                                :context {:token token}})
+          (ai-usage-logs/log! db {:org-id org-id
+                                  :user-id user-id
+                                  :feature-type "invite"
+                                  :input-tokens 0
+                                  :output-tokens 0})
           [::response/ok {:org_id org-id :token token}])
         [::response/forbidden {:error "Insufficient role"}]))))
 
@@ -37,5 +43,10 @@
                                :user-id user-id
                                :action "accept-invite"
                                :context {:token token}})
+          (ai-usage-logs/log! db {:org-id org_id
+                                  :user-id user-id
+                                  :feature-type "invite"
+                                  :input-tokens 0
+                                  :output-tokens 0})
           [::response/ok {:org_id org_id :token token :status "accepted"}])
         [::response/bad-request {:error "Invalid token"}]))))

--- a/src/etlp_mapper/handler/me.clj
+++ b/src/etlp_mapper/handler/me.clj
@@ -1,12 +1,23 @@
 (ns etlp-mapper.handler.me
   (:require [ataraxy.response :as response]
-            [integrant.core :as ig]))
+            [integrant.core :as ig]
+            [etlp-mapper.audit-logs :as audit-logs]
+            [etlp-mapper.ai-usage-logs :as ai-usage-logs]))
 
 ;; POST /me/active-org – set the currently active organisation for the user.
 ;; The real implementation would persist this choice and perhaps issue a new
 ;; token.  Here we simply echo back the requested organisation identifier.
 (defmethod ig/init-key :etlp-mapper.handler.me/set-active-org
-  [_ _]
-  (fn [{{:keys [org_id]} :body-params}]
-    [::response/ok {:org_id org_id}]))
+  [_ {:keys [db]}]
+  (fn [{{:keys [org_id]} :body-params :as request}]
+    (let [user-id (get-in request [:identity :claims :sub])]
+      (audit-logs/log! db {:org-id org_id
+                           :user-id user-id
+                           :action "set-active-org"})
+      (ai-usage-logs/log! db {:org-id org_id
+                              :user-id user-id
+                              :feature-type "active-org"
+                              :input-tokens 0
+                              :output-tokens 0})
+      [::response/ok {:org_id org_id}])))
 

--- a/src/etlp_mapper/handler/orgs.clj
+++ b/src/etlp_mapper/handler/orgs.clj
@@ -1,7 +1,8 @@
 (ns etlp-mapper.handler.orgs
   (:require [ataraxy.response :as response]
             [integrant.core :as ig]
-            [etlp-mapper.audit-logs :as audit-logs]))
+            [etlp-mapper.audit-logs :as audit-logs]
+            [etlp-mapper.ai-usage-logs :as ai-usage-logs]))
 
 ;; Handler for creating a new organization. Requires an authenticated user
 ;; without an active organisation association. The real implementation would
@@ -18,5 +19,10 @@
         (audit-logs/log! db {:org-id new-id
                              :user-id user-id
                              :action "create-organization"})
+        (ai-usage-logs/log! db {:org-id new-id
+                                :user-id user-id
+                                :feature-type "onboarding"
+                                :input-tokens 0
+                                :output-tokens 0})
         [::response/ok {:org_id new-id}]))))
 

--- a/test/etlp_mapper/mapping_operations_test.clj
+++ b/test/etlp_mapper/mapping_operations_test.clj
@@ -1,7 +1,12 @@
 (ns etlp-mapper.mapping-operations-test
   (:require [clojure.test :refer :all]
+            [ataraxy.response :as response]
             [ring.util.http-response :as http]
-            [etlp-mapper.auth :as auth]))
+            [etlp-mapper.auth :as auth]
+            [integrant.core :as ig]
+            [etlp-mapper.audit-logs :as audit-logs]
+            [etlp-mapper.ai-usage-logs :as ai-usage-logs]
+            [etlp-mapper.handler.mappings :as mappings]))
 
 (defn create-handler [req]
   (http/ok {:org/id (get-in req [:identity :org/id])}))
@@ -16,4 +21,45 @@
   (let [app ((auth/require-role :mapper) create-handler)
         resp (app {:identity {:org/id "org-1" :roles #{:viewer}}})]
     (is (= 403 (:status resp)))))
+
+(deftest mapping-lifecycle-logs
+  (let [audit (atom [])
+        ai (atom [])
+        db {}
+        org-id "org-1"
+        user-id (str (java.util.UUID/randomUUID))
+        create-h (ig/init-key :etlp-mapper.handler.mappings/create {:db db
+                                                                    :handler (fn [_] [::response/created {:id 1}])})
+        update-h (ig/init-key :etlp-mapper.handler.mappings/update {:db db
+                                                                    :handler (fn [_] [::response/no-content nil])})
+        destroy-h (ig/init-key :etlp-mapper.handler.mappings/destroy {:db db
+                                                                      :handler (fn [_] [::response/no-content nil])})
+        apply-h (ig/init-key :etlp-mapper.handler/apply-mappings {:db db})]
+    (with-redefs [audit-logs/log! (fn [_ data] (swap! audit conj data))
+                  ai-usage-logs/log! (fn [_ data] (swap! ai conj data))
+                  mappings/apply-mapping (fn [_ _ _ _] {:ok true})]
+      (create-h {:identity {:org/id org-id :claims {:sub user-id}}
+                 :ataraxy/result [::any "Example" {:content true}]})
+      (update-h {:identity {:org/id org-id :claims {:sub user-id}}
+                 :ataraxy/result [::any 1 {:content true}]})
+      (apply-h {:ataraxy/result [::any 1 {}]
+                :identity {:org/id org-id :claims {:sub user-id}}})
+      (destroy-h {:identity {:org/id org-id :claims {:sub user-id}}
+                  :ataraxy/result [::any 1]})
+      (let [audit-events @audit
+            ai-events @ai]
+        (is (= 4 (count audit-events)))
+        (is (= ["create-mapping" "update-mapping" "apply-mapping" "destroy-mapping"]
+               (map :action audit-events)))
+        (is (= ["mapping-create" "mapping-update" "transform" "mapping-delete"]
+               (map :feature-type ai-events)))
+        (is (= [org-id org-id org-id org-id]
+               (map :org-id audit-events)))
+        (is (= [user-id user-id user-id user-id]
+               (map :user-id audit-events)))
+        (is (= "Example" (get-in audit-events [0 :context :title])))
+        (is (= 1 (get-in audit-events [1 :context :mapping-id])))
+        (is (= {:mapping-id 1} (get-in audit-events [3 :context])))
+        (is (every? zero? (map :input-tokens ai-events)))
+        (is (every? zero? (map :output-tokens ai-events)))))))
 

--- a/test/etlp_mapper/onboarding_test.clj
+++ b/test/etlp_mapper/onboarding_test.clj
@@ -1,31 +1,44 @@
 (ns etlp-mapper.onboarding-test
-  (:require [clojure.test :refer :all]))
+  (:require [clojure.test :refer :all]
+            [integrant.core :as ig]
+            [etlp-mapper.audit-logs :as audit-logs]
+            [etlp-mapper.ai-usage-logs :as ai-usage-logs]
+            [etlp-mapper.handler.orgs]
+            [etlp-mapper.handler.invites]
+            [etlp-mapper.handler.me]))
 
-(defonce db (atom {:orgs {} :invites {} :active {}}))
-
-(use-fixtures :each (fn [f]
-                      (reset! db {:orgs {} :invites {} :active {}})
-                      (f)))
-
-(defn create-org [name]
-  (let [id (str "org-" (inc (count (:orgs @db))))]
-    (swap! db assoc-in [:orgs id] {:id id :name name})
-    id))
-
-(defn send-invite [org-id email]
-  (swap! db assoc-in [:invites email] {:org-id org-id :status :pending}))
-
-(defn accept-invite [email]
-  (swap! db update-in [:invites email] assoc :status :accepted))
-
-(defn set-active-org [user-email org-id]
-  (swap! db assoc-in [:active user-email] org-id))
-
-(deftest onboarding-flow
-  (let [org-id (create-org "Acme")
-        _ (send-invite org-id "user@example.com")
-        _ (accept-invite "user@example.com")
-        _ (set-active-org "user@example.com" org-id)]
-    (is (= org-id (get-in @db [:active "user@example.com"])))
-    (is (= :accepted (get-in @db [:invites "user@example.com" :status])))))
+(deftest onboarding-flow-logs
+  (let [audit (atom [])
+        ai (atom [])
+        db {}
+        user-id (str (java.util.UUID/randomUUID))
+        create-org (ig/init-key :etlp-mapper.handler.orgs/create {:db db})
+        invite-create (ig/init-key :etlp-mapper.handler.invites/create {:db db})
+        invite-accept (ig/init-key :etlp-mapper.handler.invites/accept {:db db})
+        set-active (ig/init-key :etlp-mapper.handler.me/set-active-org {:db db})]
+    (with-redefs [audit-logs/log! (fn [_ data] (swap! audit conj data))
+                  ai-usage-logs/log! (fn [_ data] (swap! ai conj data))]
+      (let [[_ {:keys [org_id]}] (create-org {:identity {:claims {:sub user-id}}})]
+        (invite-create {:ataraxy/result [::any org_id]
+                        :identity {:claims {:sub user-id :roles #{:owner}}}})
+        (invite-accept {:body-params {:token "t" :org_id org_id}
+                        :identity {:claims {:sub user-id}}})
+        (set-active {:body-params {:org_id org_id}
+                     :identity {:claims {:sub user-id}}})
+        (let [audit-events @audit
+              ai-events @ai]
+          (is (= 4 (count audit-events)))
+          (is (= 4 (count ai-events)))
+          (is (= [org_id org_id org_id org_id]
+                 (map :org-id audit-events)))
+          (is (= [user-id user-id user-id user-id]
+                 (map :user-id audit-events)))
+          (is (= ["create-organization" "create-invite" "accept-invite" "set-active-org"]
+                 (map :action audit-events)))
+          (is (string? (get-in audit-events [1 :context :token])))
+          (is (= "t" (get-in audit-events [2 :context :token])))
+          (is (= ["onboarding" "invite" "invite" "active-org"]
+                 (map :feature-type ai-events)))
+          (is (every? zero? (map :input-tokens ai-events)))
+          (is (every? zero? (map :output-tokens ai-events))))))))
 


### PR DESCRIPTION
## Summary
- ensure audit and AI usage logging runs across onboarding, invites, active-org selection, and the full mapping lifecycle with defaulted token counts
- wrap the mapping create/update/destroy SQL handlers so they emit audit and AI usage events while keeping existing apply logic
- expand onboarding and mapping lifecycle tests to assert detailed audit contexts and AI usage entries after each action

## Testing
- `lein test etlp-mapper.onboarding-test etlp-mapper.mapping-operations-test`


------
https://chatgpt.com/codex/tasks/task_e_68c38744397483209d1f1bab01d14f6f