### PR TITLE
Ensure Ataraxy response keywords resolve cleanly

### DIFF
--- a/src/etlp_mapper/handler/index.clj
+++ b/src/etlp_mapper/handler/index.clj
@@ -1,6 +1,6 @@
 (ns etlp-mapper.handler.index
-  (:require [ataraxy.core :as ataraxy]
-            [ataraxy.response :as response]
+  (:require [ataraxy.response :as response]
+            [ataraxy.core :as ataraxy]
             [integrant.core :as ig]))
 
 (defmethod ig/init-key :etlp-mapper.handler/index [_ _]

--- a/src/etlp_mapper/handler/invites.clj
+++ b/src/etlp_mapper/handler/invites.clj
@@ -1,6 +1,5 @@
 (ns etlp-mapper.handler.invites
-  (:require [ataraxy.response :as response]
-            [integrant.core :as ig]
+  (:require [integrant.core :as ig]
             [etlp-mapper.audit-logs :as audit-logs]
             [etlp-mapper.identity :as identity]
             [etlp-mapper.ai-usage-logs :as ai-usage-logs]
@@ -9,7 +8,7 @@
   (:import (java.time Instant)
            (java.time.temporal ChronoUnit)
            (java.util UUID)
-           (java.sql Timestamp))
+           (java.sql Timestamp)))
 
 (defn- admin-role? [roles]
   (some #{:owner :admin} roles))
@@ -39,19 +38,19 @@
           invite-role (or role "mapper")]
       (cond
         (nil? org-id)
-        [::response/forbidden {:error "Organization context required"}]
+        [:ataraxy.response/forbidden {:error "Organization context required"}]
 
         (not= path-org org-id)
-        [::response/forbidden {:error "Organization mismatch"}]
+        [:ataraxy.response/forbidden {:error "Organization mismatch"}]
 
         (nil? user-id)
-        [::response/forbidden {:error "User context required"}]
+        [:ataraxy.response/forbidden {:error "User context required"}]
 
         (not (admin-role? roles))
-        [::response/forbidden {:error "Insufficient role"}]
+        [:ataraxy.response/forbidden {:error "Insufficient role"}]
 
         (not (seq email))
-        [::response/bad-request {:error "Invite email required"}]
+        [:ataraxy.response/bad-request {:error "Invite email required"}]
 
         :else
         (let [token-value (org-invites/sign-token secret {:org-id org-id
@@ -76,7 +75,7 @@
                                   :feature-type "invite"
                                   :input-tokens 0
                                   :output-tokens 0})
-          [::response/ok {:org_id org-id :token token-value}])))))
+          [:ataraxy.response/ok {:org_id org-id :token token-value}])))))
 
 ;; POST /invites/accept – verify an invite token and add the user to the
 ;; organisation membership list.
@@ -92,25 +91,25 @@
           invite    (when org-id (org-invites/find-invite db org-id token))]
       (cond
         (nil? token)
-        [::response/bad-request {:error "Invalid token"}]
+        [:ataraxy.response/bad-request {:error "Invalid token"}]
 
         (nil? claims)
-        [::response/bad-request {:error "Invalid token"}]
+        [:ataraxy.response/bad-request {:error "Invalid token"}]
 
         (nil? org-id)
-        [::response/forbidden {:error "Organization context required"}]
+        [:ataraxy.response/forbidden {:error "Organization context required"}]
 
         (and claim-org (not= claim-org org-id))
-        [::response/forbidden {:error "Organization mismatch"}]
+        [:ataraxy.response/forbidden {:error "Organization mismatch"}]
 
         (and org_id (not= org_id org-id))
-        [::response/forbidden {:error "Organization mismatch"}]
+        [:ataraxy.response/forbidden {:error "Organization mismatch"}]
 
         (nil? user-id)
-        [::response/forbidden {:error "User context required"}]
+        [:ataraxy.response/forbidden {:error "User context required"}]
 
         (nil? invite)
-        [::response/bad-request {:error "Invite not found"}]
+        [:ataraxy.response/bad-request {:error "Invite not found"}]
 
         :else
         (do
@@ -128,4 +127,4 @@
                                   :feature-type "invite"
                                   :input-tokens 0
                                   :output-tokens 0})
-          [::response/ok {:org_id org-id :token token :status "accepted"}])))))
+          [:ataraxy.response/ok {:org_id org-id :token token :status "accepted"}])))))

--- a/src/etlp_mapper/middlewares.clj
+++ b/src/etlp_mapper/middlewares.clj
@@ -1,9 +1,8 @@
 (ns etlp-mapper.middlewares
-  (:require
-    [ring.middleware.cors :refer [wrap-cors]]
-   [ataraxy.core :as ataraxy]
-   [ataraxy.response :as response]
-   [integrant.core :as ig]))
+  (:require [ataraxy.response :as response]
+            [ataraxy.core :as ataraxy]
+            [integrant.core :as ig]
+            [ring.middleware.cors :refer [wrap-cors]]))
 
 (defn dead-cors-middleware
 

--- a/test/etlp_mapper/handler/me_test.clj
+++ b/test/etlp_mapper/handler/me_test.clj
@@ -1,8 +1,8 @@
 (ns etlp-mapper.handler.me-test
-  (:require [clojure.test :refer :all]
+  (:require [ataraxy.response :as response]
             [clojure.java.jdbc :as jdbc]
+            [clojure.test :refer :all]
             [integrant.core :as ig]
-            [ataraxy.response :as response]
             [etlp-mapper.audit-logs :as audit-logs]
             [etlp-mapper.ai-usage-logs :as ai-usage-logs]
             ;; ensure handler namespace is loaded for init-key method

--- a/test/etlp_mapper/handler/whoami_test.clj
+++ b/test/etlp_mapper/handler/whoami_test.clj
@@ -1,7 +1,7 @@
 (ns etlp-mapper.handler.whoami-test
-  (:require [clojure.test :refer :all]
+  (:require [ataraxy.response :as response]
+            [clojure.test :refer :all]
             [integrant.core :as ig]
-            [ataraxy.response :as response]
             [etlp-mapper.handler.whoami]))
 
 (deftest whoami-reads-identity

--- a/test/etlp_mapper/mapping_operations_test.clj
+++ b/test/etlp_mapper/mapping_operations_test.clj
@@ -1,6 +1,6 @@
 (ns etlp-mapper.mapping-operations-test
-  (:require [clojure.test :refer :all]
-            [ataraxy.response :as response]
+  (:require [ataraxy.response :as response]
+            [clojure.test :refer :all]
             [ring.util.http-response :as http]
             [etlp-mapper.auth :as auth]
             [integrant.core :as ig]


### PR DESCRIPTION
## Summary
- reorder namespace requires so ataraxy.response is explicitly aliased where ::response keywords are used
- update invites handler to emit :ataraxy.response/* keywords directly to avoid reader errors and close its ns form properly

## Testing
- lein check

------
https://chatgpt.com/codex/tasks/task_e_68cc2287c7348320b9ccb35d7c9d09c6