### PR TITLE
Fix org scope regex to escape quotes

### DIFF
--- a/test/etlp_mapper/validation/org_scope_test.clj
+++ b/test/etlp_mapper/validation/org_scope_test.clj
@@ -18,7 +18,7 @@
   (doseq [file (clj-files)
           :when (not (skip-files file))]
     (let [content (slurp file)]
-      (doseq [[_ sql] (re-seq #"jdbc/query[^\[]*\[\s*\"([^"]+)" content)]
+      (doseq [[_ sql] (re-seq #"jdbc/query[^\[]*\[\s*\"([^\"]+)\"" content)]
         (let [upper (str/upper-case sql)]
           (when (and (str/includes? upper "SELECT")
                      (not (re-find #"ORGANIZATION_ID" upper)))


### PR DESCRIPTION
## Summary
- update the org scope validation regex to escape the quoted identifier inside the capture group so it compiles cleanly

## Testing
- `lein test` *(fails: requires database credentials and invite secrets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc32a07828832099b407173a9be287