### PR TITLE
Allow overriding auth DB helpers

### DIFF
--- a/src/etlp_mapper/auth.clj
+++ b/src/etlp_mapper/auth.clj
@@ -101,11 +101,16 @@
 
   Options: `:issuer`, `:audience`, `:jwks-uri`, `:db`.  For testing a
   custom `:verifier` function may be supplied which should return a
-  `DecodedJWT` when given a token."
-  [{:keys [issuer audience jwks-uri verifier db]}]
+  `DecodedJWT` when given a token.  The default database helpers may be
+  overridden via `:upsert-user!`, `:update-last-org!` and
+  `:load-user-roles`."
+  [{:keys [issuer audience jwks-uri verifier db] :as opts}]
   (when (nil? db)
     (throw (ex-info "Database connection must be configured" {})))
-  (let [verify (or verifier (build-verifier issuer audience jwks-uri))]
+  (let [verify (or verifier (build-verifier issuer audience jwks-uri))
+        upsert-user! (or (:upsert-user! opts) upsert-user!)
+        update-last-org! (or (:update-last-org! opts) update-last-org!)
+        load-user-roles (or (:load-user-roles opts) load-user-roles)]
     (fn [handler]
       (fn [req]
         (if-let [token (bearer-token req)]

--- a/test/etlp_mapper/auth_test.clj
+++ b/test/etlp_mapper/auth_test.clj
@@ -36,18 +36,21 @@
   (let [{:keys [token verifier]} (gen-token {:sub "sub-1" :email "u@example" :name "User"})
         handler (fn [req] (http/ok (get req :identity)))
         upsert (fn [_ _] {:id 1 :email "u@example" :idp_sub "sub-1" :last_used_org_id nil})
-        roles  (fn [_ _ _] ["admin"])]
-    (with-redefs [auth/upsert-user! upsert
-                  auth/load-user-roles roles
-                  auth/update-last-org! (fn [_ _ _])]
-      (let [app ((auth/wrap-auth {:issuer issuer :audience audience :verifier verifier :db ::db})
-                 ((auth/wrap-require-org) handler))
-            resp (app {:headers {"authorization" (str "Bearer " token)
-                                 "x-org-id" "org-1"}})]
-        (is (= 200 (:status resp)))
-        (is (= "org-1" (get-in resp [:body :org/id])))
-        (is (= #{:admin} (get-in resp [:body :roles])))
-        (is (= "sub-1" (get-in resp [:body :claims :sub])))))))
+        roles  (fn [_ _ _] ["admin"])
+        app ((auth/wrap-auth {:issuer issuer
+                              :audience audience
+                              :verifier verifier
+                              :db ::db
+                              :upsert-user! upsert
+                              :load-user-roles roles
+                              :update-last-org! (fn [_ _ _])})
+             ((auth/wrap-require-org) handler))
+        resp (app {:headers {"authorization" (str "Bearer " token)
+                             "x-org-id" "org-1"}})]
+    (is (= 200 (:status resp)))
+    (is (= "org-1" (get-in resp [:body :org/id])))
+    (is (= #{:admin} (get-in resp [:body :roles])))
+    (is (= "sub-1" (get-in resp [:body :claims :sub])))))
 
 (deftest jwt-missing-org
   (let [{:keys [token verifier]} (gen-token {:sub "s" :email "e" :name "n"})
@@ -55,15 +58,18 @@
         handler (fn [_]
                   (reset! called true)
                   (http/ok))
-        upsert (fn [_ _] {:id 1 :email "e" :idp_sub "s" :last_used_org_id nil})]
-    (with-redefs [auth/upsert-user! upsert
-                  auth/load-user-roles (fn [& _] [])
-                  auth/update-last-org! (fn [_ _ _])]
-      (let [app ((auth/wrap-auth {:issuer issuer :audience audience :verifier verifier :db ::db})
-                 ((auth/wrap-require-org) handler))
-            resp (app {:headers {"authorization" (str "Bearer " token)}})]
-        (is (= 403 (:status resp)))
-        (is (false? @called))))))
+        upsert (fn [_ _] {:id 1 :email "e" :idp_sub "s" :last_used_org_id nil})
+        app ((auth/wrap-auth {:issuer issuer
+                              :audience audience
+                              :verifier verifier
+                              :db ::db
+                              :upsert-user! upsert
+                              :load-user-roles (fn [& _] [])
+                              :update-last-org! (fn [_ _ _])})
+             ((auth/wrap-require-org) handler))
+        resp (app {:headers {"authorization" (str "Bearer " token)}})]
+    (is (= 403 (:status resp)))
+    (is (false? @called))))
 
 (deftest jwt-invalid
   (let [{:keys [token]} (gen-token {:org_id "org-1"})
@@ -87,14 +93,18 @@
 (deftest jwt-db-error
   (let [{:keys [token verifier]} (gen-token {:sub "s" :email "e" :name "n"})
         handler (fn [_] (http/ok))
-        failing-upsert (fn [_ _] (throw (IllegalArgumentException. "db-spec null is missing a required parameter")))]
-    (with-redefs [auth/upsert-user! failing-upsert
-                  auth/load-user-roles (fn [& _] [])
-                  auth/update-last-org! (fn [& _] nil)]
-      (let [app ((auth/wrap-auth {:issuer issuer :audience audience :verifier verifier :db ::db}) handler)
-            resp (app {:headers {"authorization" (str "Bearer " token)}})]
-        (is (= 500 (:status resp)))
-        (is (= "db-spec null is missing a required parameter" (get-in resp [:body :error])))))))
+        failing-upsert (fn [_ _] (throw (IllegalArgumentException. "db-spec null is missing a required parameter")))
+        app ((auth/wrap-auth {:issuer issuer
+                              :audience audience
+                              :verifier verifier
+                              :db ::db
+                              :upsert-user! failing-upsert
+                              :load-user-roles (fn [& _] [])
+                              :update-last-org! (fn [& _] nil)})
+             handler)
+        resp (app {:headers {"authorization" (str "Bearer " token)}})]
+    (is (= 500 (:status resp)))
+    (is (= "db-spec null is missing a required parameter" (get-in resp [:body :error])))))
 
 (deftest route-protection
   (let [handler (fn [_] (http/ok))

--- a/test/etlp_mapper/validation/contract_test.clj
+++ b/test/etlp_mapper/validation/contract_test.clj
@@ -43,12 +43,15 @@
         handler (fn [req] (http/ok (get-in req [:identity :roles])))
         upsert (fn [_ _] {:id "user-1" :email "user@example.com" :idp_sub "sub" :last_used_org_id nil})
         roles  (fn [& _] ["editor"])
-        app ((auth/wrap-auth {:issuer issuer :audience audience :verifier verifier :db ::db})
+        app ((auth/wrap-auth {:issuer issuer
+                              :audience audience
+                              :verifier verifier
+                              :db ::db
+                              :upsert-user! upsert
+                              :load-user-roles roles
+                              :update-last-org! (fn [& _] nil)})
              ((auth/wrap-require-org) handler))]
-    (with-redefs [auth/upsert-user! upsert
-                  auth/load-user-roles roles
-                  auth/update-last-org! (fn [& _] nil)
-                  audit-logs/log! (fn [& _] nil)
+    (with-redefs [audit-logs/log! (fn [& _] nil)
                   ai-usage-logs/log! (fn [& _] nil)]
       (let [resp (app (-> (mock/request :get "/mappings")
                           (mock/header "authorization" (str "Bearer " token))
@@ -60,13 +63,16 @@
   (let [{:keys [token verifier]} (token-with-claims {:sub "user-1" :email "user@example.com"})
         handler (fn [_] (http/ok))
         upsert (fn [_ _] {:id "user-1" :email "user@example.com" :idp_sub "sub" :last_used_org_id nil})
-        app ((auth/wrap-auth {:issuer issuer :audience audience :verifier verifier :db ::db})
+        app ((auth/wrap-auth {:issuer issuer
+                              :audience audience
+                              :verifier verifier
+                              :db ::db
+                              :upsert-user! upsert
+                              :load-user-roles (fn [& _] [])
+                              :update-last-org! (fn [& _] nil)})
              ((auth/wrap-require-org) handler))]
-    (with-redefs [auth/upsert-user! upsert
-                  auth/load-user-roles (fn [& _] [])
-                  auth/update-last-org! (fn [& _] nil)]
-      (let [resp (app (mock/header (mock/request :get "/mappings") "authorization" (str "Bearer " token)))]
-        (is (= 403 (:status resp)))))))
+    (let [resp (app (mock/header (mock/request :get "/mappings") "authorization" (str "Bearer " token)))]
+      (is (= 403 (:status resp))))))
 
 (deftest role-guard-contract
   (let [handler (fn [_] (http/ok))


### PR DESCRIPTION
## Summary
- allow `wrap-auth` to accept optional overrides for the database helper fns so callers can inject stubs
- update auth and contract validation tests to pass stubbed helpers through the new options

## Testing
- `lein test :only etlp-mapper.auth-test`
- `lein test :only etlp-mapper.validation.contract-test`


------
https://chatgpt.com/codex/tasks/task_e_68cc3c261fd88320bd57a744c389aa74