### PR TITLE
Add Integrant component for Keycloak admin configuration

### DIFF
--- a/src/etlp_mapper/keycloak.clj
+++ b/src/etlp_mapper/keycloak.clj
@@ -1,0 +1,10 @@
+(ns etlp-mapper.keycloak
+  (:require [integrant.core :as ig]))
+
+(defmethod ig/init-key :etlp-mapper.keycloak/admin
+  [_ config]
+  config)
+
+(defmethod ig/halt-key! :etlp-mapper.keycloak/admin
+  [_ _]
+  nil)

--- a/src/etlp_mapper/main.clj
+++ b/src/etlp_mapper/main.clj
@@ -3,7 +3,8 @@
   (:require [duct.core :as duct]
             [etlp-mapper.pgtypes]
             [etlp-mapper.auth-component]
-            [etlp-mapper.middlewares]))
+            [etlp-mapper.middlewares]
+            [etlp-mapper.keycloak]))
 
 (duct/load-hierarchy)
 


### PR DESCRIPTION
## Summary
- add a Keycloak namespace that registers the :etlp-mapper.keycloak/admin Integrant component
- ensure the Keycloak namespace is loaded during application startup

## Testing
- `lein test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b6bf1e288320a375896919c20efc