### PR TITLE
Add API documentation artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ This service can be used as a standalone Jute based data transformation utility,
 ## Setup
 
 
+### API Documentation & Collections
+
+Generated assets for exploring the HTTP surface live under `docs/api/`:
+
+- `openapi.yaml` provides a complete OpenAPI 3 contract for onboarding, invitation,
+  billing, and mapping operations. Import it into Swagger UI/ReDoc or generate typed
+  clients as needed.
+- `etlp-mapper.postman_collection.json` mirrors the flow in Postman, complete with
+  variables for `baseUrl`, bearer token, organization ID, and history transaction IDs so
+  you can walk through sign-up → invite → mapping lifecycle calls.
+
+Download either artifact from the repo (or mount the repo inside Postman/Insomnia) and
+point `baseUrl` at your running instance—`http://localhost:3000` for the default dev
+profile. The collection headers already expose the optional `X-Org-Id` helper for
+switching context mid-session.
+
+
 ### Production Build
 
 As a precursor you would need Leiningen, Clojure and Java installed on our machine, once we have the basic runtime up an running, we need to clone this repo and build an uberjar.

--- a/docs/api/etlp-mapper.postman_collection.json
+++ b/docs/api/etlp-mapper.postman_collection.json
@@ -1,0 +1,459 @@
+{
+  "info": {
+    "name": "ETLP Mapper API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Postman collection mirroring the ETLP Mapper onboarding and mapping workflows."
+  },
+  "item": [
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "GET /",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/"
+          }
+        },
+        {
+          "name": "GET /whoami",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}",
+                "disabled": true
+              }
+            ],
+            "url": "{{baseUrl}}/whoami"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Onboarding",
+      "item": [
+        {
+          "name": "POST /orgs",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Acme Corp\"\n}"
+            },
+            "url": "{{baseUrl}}/orgs"
+          }
+        },
+        {
+          "name": "POST /me/active-org",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"org_id\": \"{{orgId}}\"\n}"
+            },
+            "url": "{{baseUrl}}/me/active-org"
+          }
+        },
+        {
+          "name": "POST /billing/portal",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "disabled": true
+              },
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}",
+                "disabled": true
+              }
+            ],
+            "url": "{{baseUrl}}/billing/portal"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Invitations",
+      "item": [
+        {
+          "name": "POST /orgs/:org_id/invites",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"user@example.com\",\n  \"role\": \"editor\",\n  \"ttl_minutes\": 120\n}"
+            },
+            "url": "{{baseUrl}}/orgs/{{orgId}}/invites"
+          }
+        },
+        {
+          "name": "POST /invites/accept",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"token\": \"<invite-token>\",\n  \"org_id\": \"{{orgId}}\"\n}"
+            },
+            "url": "{{baseUrl}}/invites/accept"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Mappings",
+      "item": [
+        {
+          "name": "GET /mappings",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "url": "{{baseUrl}}/mappings"
+          }
+        },
+        {
+          "name": "POST /mappings",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Leads Import\",\n  \"content\": {\n    \"yaml\": \"<stored YAML string>\"\n  }\n}"
+            },
+            "url": "{{baseUrl}}/mappings"
+          }
+        },
+        {
+          "name": "PUT /mappings/:id",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"content\": {\n    \"yaml\": \"<updated YAML string>\"\n  }\n}"
+            },
+            "url": "{{baseUrl}}/mappings/1"
+          }
+        },
+        {
+          "name": "POST /mappings/:id/apply",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"data\": {\n    \"sample\": \"payload\"\n  }\n}"
+            },
+            "url": "{{baseUrl}}/mappings/1/apply"
+          }
+        },
+        {
+          "name": "GET /mappings/:id",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "url": "{{baseUrl}}/mappings/1"
+          }
+        },
+        {
+          "name": "GET /mappings/:id/_history",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "url": "{{baseUrl}}/mappings/1/_history"
+          }
+        },
+        {
+          "name": "GET /mappings/:id/_history/:version",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "url": "{{baseUrl}}/mappings/1/_history/{{txnid}}"
+          }
+        },
+        {
+          "name": "DELETE /mappings/:id",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "url": "{{baseUrl}}/mappings/1"
+          }
+        },
+        {
+          "name": "POST /mappings/test",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "text/yaml"
+              },
+              {
+                "key": "X-Org-Id",
+                "value": "{{orgId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "template:\n  - set:\n      path: result\n      value: '{{data.value}}'\nscope:\n  data:\n    value: example"
+            },
+            "url": "{{baseUrl}}/mappings/test"
+          }
+        }
+      ]
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3000"
+    },
+    {
+      "key": "token",
+      "value": ""
+    },
+    {
+      "key": "orgId",
+      "value": ""
+    },
+    {
+      "key": "txnid",
+      "value": ""
+    }
+  ]
+}

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,534 @@
+openapi: 3.0.3
+info:
+  title: ETLP Mapper API
+  version: 1.0.0
+  description: |
+    Contract for the ETLP Mapper service covering onboarding, invitations, organization
+    management, billing portal access, and mapping lifecycle operations.
+servers:
+  - url: http://localhost:3000
+    description: Local development
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    OrgIdHeader:
+      name: X-Org-Id
+      in: header
+      description: >-
+        Optional organization identifier. When supplied, the backend switches the active
+        organization for the duration of the request and persists it as the user's last
+        used organization.
+      schema:
+        type: string
+        format: uuid
+  schemas:
+    Mapping:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        content:
+          type: object
+        organization_id:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - title
+        - organization_id
+    MappingHistory:
+      type: object
+      properties:
+        title:
+          type: string
+        content:
+          type: object
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        txnid:
+          type: string
+      required:
+        - title
+        - txnid
+paths:
+  /:
+    get:
+      summary: Health check
+      description: Returns a static payload confirming the service is reachable.
+      responses:
+        '200':
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /whoami:
+    get:
+      summary: Inspect the authenticated identity
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/OrgIdHeader'
+      responses:
+        '200':
+          description: Current user identity, roles, and active organization.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    type: object
+                    nullable: true
+                    description: Claims captured from the Keycloak token.
+                  org_id:
+                    type: string
+                    format: uuid
+                    nullable: true
+                  roles:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - roles
+  /orgs:
+    post:
+      summary: Create an organization for the caller
+      description: >-
+        Creates a new organization, assigns the caller as owner, provisions the default
+        subscription, logs the onboarding event, and marks the organization as active for
+        the user.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+      responses:
+        '200':
+          description: Organization successfully provisioned.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  org_id:
+                    type: string
+                    format: uuid
+                required:
+                  - org_id
+        '400':
+          description: Missing or invalid payload.
+        '403':
+          description: Organization already selected or user missing.
+  /orgs/{org_id}/invites:
+    post:
+      summary: Issue an invitation for an organization member
+      description: Generates a signed invite token and stores it for later redemption.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: org_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: '#/components/parameters/OrgIdHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                role:
+                  type: string
+                  description: Role to grant the invitee. Defaults to `mapper`.
+                ttl_minutes:
+                  type: integer
+                  description: Minutes before the invite expires. Defaults to 60.
+              required:
+                - email
+      responses:
+        '200':
+          description: Invitation successfully created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                required:
+                  - token
+        '400':
+          description: Missing email or invalid organization.
+        '403':
+          description: Authorization failure or missing organization context.
+  /invites/accept:
+    post:
+      summary: Accept an invitation token
+      description: Validates the invite and adds the authenticated user to the organization.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/OrgIdHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                org_id:
+                  type: string
+                  format: uuid
+                  nullable: true
+                  description: Optional organization identifier to assert during acceptance.
+              required:
+                - token
+      responses:
+        '200':
+          description: Invitation accepted and membership created if needed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  org_id:
+                    type: string
+                    format: uuid
+                  token:
+                    type: string
+                  status:
+                    type: string
+                    enum: [accepted]
+                required:
+                  - org_id
+                  - token
+                  - status
+        '400':
+          description: Invalid token or invite not found.
+        '403':
+          description: Organization mismatch or user context missing.
+  /me/active-org:
+    post:
+      summary: Set the active organization for the user
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                org_id:
+                  type: string
+                  format: uuid
+                  description: If omitted, the current organization context is reused.
+      responses:
+        '200':
+          description: Active organization persisted for the user.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  org_id:
+                    type: string
+                    format: uuid
+                required:
+                  - org_id
+        '400':
+          description: Missing organization identifier.
+        '403':
+          description: User not authenticated or not a member of the organization.
+  /billing/portal:
+    post:
+      summary: Retrieve the billing portal URL for the active organization
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/OrgIdHeader'
+      responses:
+        '200':
+          description: Link to the third-party billing portal.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                  org_id:
+                    type: string
+                    format: uuid
+                required:
+                  - url
+                  - org_id
+        '403':
+          description: Missing organization context or insufficient privileges.
+  /mappings:
+    get:
+      summary: List mappings for the active organization
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/OrgIdHeader'
+      responses:
+        '200':
+          description: Collection of mapping definitions.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Mapping'
+    post:
+      summary: Create a mapping definition
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/OrgIdHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                content:
+                  type: object
+                  description: Arbitrary JSON payload representing the mapping content.
+              required:
+                - title
+                - content
+      responses:
+        '201':
+          description: Mapping created.
+          headers:
+            Location:
+              description: URL of the created mapping resource.
+              schema:
+                type: string
+        '400':
+          description: Invalid payload.
+  /mappings/{id}:
+    get:
+      summary: Fetch a single mapping
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/OrgIdHeader'
+      responses:
+        '200':
+          description: Mapping payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Mapping'
+        '404':
+          description: Mapping not found for the organization.
+    put:
+      summary: Replace mapping content
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/OrgIdHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: object
+              required:
+                - content
+      responses:
+        '204':
+          description: Mapping updated.
+    delete:
+      summary: Remove a mapping
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/OrgIdHeader'
+      responses:
+        '204':
+          description: Mapping deleted.
+  /mappings/{id}/apply:
+    post:
+      summary: Apply a mapping to supplied data
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/OrgIdHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+              required:
+                - data
+      responses:
+        '200':
+          description: Transformation result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    description: Output from executing the stored mapping.
+                    nullable: true
+                  'org/id':
+                    type: string
+                    format: uuid
+  /mappings/{id}/_history:
+    get:
+      summary: Retrieve mapping history entries
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/OrgIdHeader'
+      responses:
+        '200':
+          description: List of historical mapping snapshots ordered by transaction.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MappingHistory'
+  /mappings/{id}/_history/{version}:
+    get:
+      summary: Retrieve a specific historical version
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Transaction identifier recorded in the mapping history.
+        - $ref: '#/components/parameters/OrgIdHeader'
+      responses:
+        '200':
+          description: Historical snapshot for the mapping.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MappingHistory'
+        '404':
+          description: Version not found.
+  /mappings/test:
+    post:
+      summary: Execute a mapping template without persisting it
+      description: >-
+        Accepts a YAML payload containing a `template` definition and `scope` data. The
+        service compiles the template, applies it to the scope, and returns the rendered
+        data without touching persisted mappings.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/OrgIdHeader'
+      requestBody:
+        required: true
+        content:
+          text/yaml:
+            schema:
+              type: string
+              description: YAML document with `template` and `scope` keys.
+          application/x-yaml:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: Rendered template result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  request:
+                    description: Output of the ad-hoc mapping execution.
+                  'org/id':
+                    type: string
+                    format: uuid
+        '400':
+          description: Template parsing or execution failure.


### PR DESCRIPTION
## Summary
- add a first-class OpenAPI 3 specification for the onboarding, invitation, billing, and mapping endpoints
- provide a Postman collection that walks through the organization, invitation, and mapping lifecycle using shared variables
- document how to import and use the new API artifacts in the README for faster developer onboarding

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1ca4c0eec832081749253c6b29dbb